### PR TITLE
Don't misuse constructor names for CellBuffer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FerriteAssembly"
 uuid = "fd21fc07-c509-4fe1-9468-19963fd5935d"
 authors = ["Knut Andreas Meyer and contributors"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 Ferrite = "c061ca5d-56c9-439f-9c0e-210fe06d3992"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -20,7 +20,9 @@ Variables that are used and modified for each cell of a certain type,
 but that don't belong to a specific cell, are collected in a `CellBuffer`.
 ```@docs
 CellBuffer
+setup_cellbuffer
 AutoDiffCellBuffer
+setup_ad_cellbuffer
 getCellBuffer
 ```
 

--- a/docs/src/firstexample_literate.jl
+++ b/docs/src/firstexample_literate.jl
@@ -48,7 +48,7 @@ states = create_states(dh);
 
 # The next step is gathering all variables that are shared for all elements,
 # but may be modified for or by each element in the `cellbuffer`:
-cellbuffer = CellBuffer(dh, cellvalues, ThermalMaterial());
+cellbuffer = setup_cellbuffer(dh, cellvalues, ThermalMaterial());
 # Note that `cellvalues` can be a `Tuple` or `NamedTuple`, 
 # this is useful for coupled problems with multiple fields. 
 
@@ -63,7 +63,7 @@ doassemble!(assembler, cellbuffer, states, dh);
 colors = create_coloring(dh.grid);
 
 # We must also create threaded versions of the `cellbuffer` and `assembler`,
-cellbuffers = create_threaded_CellBuffers(CellBuffer(dh, cellvalues, ThermalMaterial()))
+cellbuffers = create_threaded_CellBuffers(cellbuffer)
 assemblers = create_threaded_assemblers(K, r);
 
 # And then we can call `doassemble!` as
@@ -100,7 +100,7 @@ end;
 
 # In this case we need the `ae` input and must therefore define `a`:
 a = zeros(ndofs(dh))
-cellbuffer2 = CellBuffer(dh, cellvalues, ThermalMaterialAD())
+cellbuffer2 = setup_cellbuffer(dh, cellvalues, ThermalMaterialAD())
 assembler = start_assemble(K,r)
 doassemble!(assembler, cellbuffer2, states, dh, a);
 
@@ -110,5 +110,5 @@ doassemble!(assembler, cellbuffer2, states, dh, a);
 
 # By using the special [`AutoDiffCellBuffer`](@ref) that caches some variables for automatic differentiation,
 # we can significantly improve performance when using automatic differentiation. 
-cellbuffer3 = AutoDiffCellBuffer(states, dh, cellvalues, ThermalMaterialAD())
+cellbuffer3 = setup_ad_cellbuffer(states, dh, cellvalues, ThermalMaterialAD())
 @btime doassemble!(assembler, $cellbuffer3, $states, $dh) setup=(assembler=start_assemble(K,r));

--- a/docs/src/literate/MaterialModelsBaseElement.jl
+++ b/docs/src/literate/MaterialModelsBaseElement.jl
@@ -4,7 +4,7 @@
 function FerriteAssembly.element_routine!(
     Ke::AbstractMatrix, re::AbstractVector, state::Vector{<:AbstractMaterialState}, 
     ae::AbstractVector, material::AbstractMaterial, cellvalues::CellVectorValues, dh_fh, Δt, buffer::CellBuffer)
-    cache = buffer.cache
+    cache = FerriteAssembly.get_cache(buffer)
     n_basefuncs = getnbasefunctions(cellvalues)
     for q_point in 1:getnquadpoints(cellvalues)
         ## For each integration point, compute stress and material stiffness

--- a/docs/src/literate/mixed_materials.jl
+++ b/docs/src/literate/mixed_materials.jl
@@ -53,7 +53,7 @@ states = create_states(dh, statefuns, cellvalues);
 
 # We also need buffers for each material
 caches = Dict(key=>get_cache(mat) for (key,mat) in materials)
-buffers = CellBuffer(dh, cellvalues, materials, nothing, caches);
+buffers = setup_cellbuffer(dh, cellvalues, materials, nothing, caches);
 
 # And then we define the displacements and the assembler, before assembling
 a = zeros(ndofs(dh))

--- a/docs/src/literate/plasticity.jl
+++ b/docs/src/literate/plasticity.jl
@@ -24,7 +24,7 @@ r = zeros(ndofs(dh));
 states = create_states(dh, _->initial_material_state(material), cellvalues);
 
 # And then we create the buffer for saving cell-related variables
-buffer = CellBuffer(dh, cellvalues, material, nothing, get_cache(material));
+buffer = setup_cellbuffer(dh, cellvalues, material, nothing, get_cache(material));
 
 # Finally, with an initial guess of displacements, `a`, 
 # we can create the assembler and do the assembly

--- a/src/FerriteAssembly.jl
+++ b/src/FerriteAssembly.jl
@@ -40,15 +40,15 @@ This function should modify the element stiffness matrix `Ke` and the residual `
   for multi-field problems. **Note:** Please do not rely on `dh_fh` for anything but `dof_range`,
   as `dh_fh` may be replaced with another type that only supports `dof_range`.
 * `Δt` is time increment given to `doassemble`
-* `buffer` is normally `CellBuffer` (if given to `doassemble`). Then, it can be used to get 
-  - `buffer.ae_old`: The old values of the displacements (if `aold::Nothing` is passed to 
-    `doassemble`, `buffer.ae_old` will be `NaN`s)
-  - `buffer.cell_load`: The `cell_load` passed to `CellBuffer`, typically used for 
-    body loads or source terms. 
-  - `buffer.cache`: The `cache` passed to `CellBuffer`, typically used to gather all 
-    preallocations if such are necessary
+* `buffer::Union{CellBuffer, AutoDiffCellBuffer}` can be used to get 
   - `getcoordinates(buffer)::Vector{Vec}`: The cell's coordinates
   - `celldofs(buffer)::Vector{Int}`: The cell's global degrees of freedom numbers
+  - `FerriteAssembly.get_aeold(buffer)`: `aold[celldofs]` (if `aold::Nothing` is passed to 
+    `doassemble`, a vector, `[NaN for d in celldofs]` is returned)
+  - `FerriteAssembly.get_load(buffer)`: The `cell_load` in the buffer, typically used for 
+     body loads or source terms. 
+  - `FerriteAssembly.get_cache(buffer)`: The `cache` in the buffer - typically used to gather all 
+     preallocations if such are necessary
 """
 element_routine!(args...) = element_routine_ad!(args...)    # If not defined, try to use automatic differentiation
 

--- a/src/FerriteAssembly.jl
+++ b/src/FerriteAssembly.jl
@@ -12,6 +12,7 @@ include("states.jl")
 
 export doassemble!
 export CellBuffer, AutoDiffCellBuffer, getCellBuffer
+export setup_cellbuffer, setup_ad_cellbuffer
 export create_states
 export ElementResidualScaling, reset_scaling!
 export create_threaded_CellBuffers, create_threaded_assemblers, create_threaded_scalings

--- a/test/heatequation.jl
+++ b/test/heatequation.jl
@@ -127,8 +127,8 @@
     cv, _, dh = setup_heatequation(DofHandler)
     reinit!(cv, getcoordinates(dh.grid,1))
     mtrl = ThermalMaterialAD()
-    cellbuffer = CellBuffer(dh, cv, mtrl)
-    cellbuffer_ad = FerriteAssembly.AutoDiffCellBuffer([nothing,],dh,cv,mtrl)
+    cellbuffer = setup_cellbuffer(dh, cv, mtrl)
+    cellbuffer_ad = FA.setup_ad_cellbuffer([nothing,],dh,cv,mtrl)
     ae = FerriteAssembly.get_ae(cellbuffer)
     re = FerriteAssembly.get_re(cellbuffer)
     Ke = FerriteAssembly.get_Ke(cellbuffer)
@@ -156,8 +156,8 @@
                 end
 
                 @testset "$DH, $mattype, sequential" begin
-                    cellbuffer = CellBuffer(dh, cv, material)
-                    cbs = isa(material,ThermalMaterial) ? (cellbuffer,) : (cellbuffer,FerriteAssembly.AutoDiffCellBuffer(states,dh,cv,material))
+                    cellbuffer = setup_cellbuffer(dh, cv, material)
+                    cbs = isa(material,ThermalMaterial) ? (cellbuffer,) : (cellbuffer,setup_ad_cellbuffer(states,dh,cv,material))
                     for cb in cbs
                         reset_scaling!(scaling)
                         assembler = start_assemble(K, r)
@@ -172,8 +172,8 @@
                     end
                 end
                 @testset "$DH, $mattype, threaded" begin
-                    cellbuffer = CellBuffer(dh, cv, material)
-                    cbs = isa(material,ThermalMaterial) ? (cellbuffer,) : (cellbuffer,FerriteAssembly.AutoDiffCellBuffer(states,dh,cv,material))
+                    cellbuffer = setup_cellbuffer(dh, cv, material)
+                    cbs = isa(material,ThermalMaterial) ? (cellbuffer,) : (cellbuffer,setup_ad_cellbuffer(states,dh,cv,material))
                     for cb in cbs
                         reset_scaling!(scaling)
                         cellbuffers = create_threaded_CellBuffers(cb)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Ferrite, FerriteAssembly
 using SparseArrays
 using Test
+import FerriteAssembly as FA
 
 @testset "FerriteAssembly.jl" begin
     include("heatequation.jl")
@@ -15,8 +16,8 @@ using Test
         r = zeros(ndofs(dh))
         a = zeros(ndofs(dh))
         # Check error when element_residual! is not defined. 
-        cb = CellBuffer(dh, cv, nothing)    # material=nothing not supported
-        cb_ad = AutoDiffCellBuffer(states, dh, cv, nothing)
+        cb = setup_cellbuffer(dh, cv, nothing)    # material=nothing not supported
+        cb_ad = setup_ad_cellbuffer(states, dh, cv, nothing)
         exception = ErrorException("Did not find correctly defined element_routine! or element_residual!")
         @test_throws exception doassemble!(start_assemble(K,r), cb, states, dh, a)
         @test_throws exception doassemble!(start_assemble(K,r), cb_ad, states, dh, a)
@@ -29,7 +30,7 @@ using Test
         function FerriteAssembly.element_residual!(re, state, ae, m::_TestMaterial, args...)
             state[1] = first(ae) # Not allowed, must be state[1] = ForwardDiff.value(first(ae))
         end
-        cb_dualissue = AutoDiffCellBuffer(states_dualissue, dh, cv, _TestMaterial())
+        cb_dualissue = setup_ad_cellbuffer(states_dualissue, dh, cv, _TestMaterial())
         @test_throws MethodError doassemble!(start_assemble(K,r), cb_dualissue, states_dualissue, dh, a) 
 
         # Check that error thrown for mismatch between parallel buffer sizes and number of threads 


### PR DESCRIPTION
Better to have different names for the constructors, since these don't always return the type (it may be wrapped in tuples/dicts)