### PR TITLE
Fix autodiff with states

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.8.2"
+julia_version = "1.8.5"
 manifest_format = "2.0"
 project_hash = "fc1fff123a99697e5961cb20fab8f5522aea62fb"
 
@@ -27,21 +27,21 @@ version = "1.3.2"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "e7ff6cadf743c098e08fca25c91103ee4303c9bb"
+git-tree-sha1 = "c6d890a52d2c4d55d326439580c3b8d0875a77d9"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.15.6"
+version = "1.15.7"
 
 [[deps.ChangesOfVariables]]
 deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
-git-tree-sha1 = "38f7a08f19d8810338d4f5085211c7dfa5d5bdd8"
+git-tree-sha1 = "485193efd2176b88e6622a39a246f8c5b600e74e"
 uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
-version = "0.1.4"
+version = "0.1.6"
 
 [[deps.CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
-git-tree-sha1 = "ded953804d019afa9a3f98981d99b33e3db7b6da"
+git-tree-sha1 = "9c209fb7536406834aa938fb149964b985de6c83"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
-version = "0.7.0"
+version = "0.7.1"
 
 [[deps.CommonSubexpressions]]
 deps = ["MacroTools", "Test"]
@@ -51,14 +51,14 @@ version = "0.3.0"
 
 [[deps.Compat]]
 deps = ["Dates", "LinearAlgebra", "UUIDs"]
-git-tree-sha1 = "3ca828fe1b75fa84b021a7860bd039eaea84d2f2"
+git-tree-sha1 = "7a60c856b9fa189eb34f5f8a6f6b5529b7942957"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.3.0"
+version = "4.6.1"
 
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "0.5.2+0"
+version = "1.0.1+0"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -72,27 +72,27 @@ version = "1.1.0"
 
 [[deps.DiffRules]]
 deps = ["IrrationalConstants", "LogExpFunctions", "NaNMath", "Random", "SpecialFunctions"]
-git-tree-sha1 = "c5b6685d53f933c11404a3ae9822afe30d522494"
+git-tree-sha1 = "a4ad7ef19d2cdc2eff57abbbe68032b1cd0bd8f8"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
-version = "1.12.2"
+version = "1.13.0"
 
 [[deps.Distances]]
 deps = ["LinearAlgebra", "SparseArrays", "Statistics", "StatsAPI"]
-git-tree-sha1 = "3258d0659f812acde79e8a74b11f17ac06d0ca04"
+git-tree-sha1 = "49eba9ad9f7ead780bfb7ee319f962c811c6d3b2"
 uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
-version = "0.10.7"
+version = "0.10.8"
 
 [[deps.DocStringExtensions]]
 deps = ["LibGit2"]
-git-tree-sha1 = "5158c2b41018c5f7eb1470d558127ac274eca0c9"
+git-tree-sha1 = "2fb1e02f2b635d0845df5d7c167fec4dd739b00d"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.9.1"
+version = "0.9.3"
 
 [[deps.Documenter]]
 deps = ["ANSIColoredPrinters", "Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "6030186b00a38e9d0434518627426570aac2ef95"
+git-tree-sha1 = "58fea7c536acd71f3eef6be3b21c0df5f3df88fd"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.27.23"
+version = "0.27.24"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
@@ -100,36 +100,36 @@ uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 version = "1.6.0"
 
 [[deps.EnumX]]
-git-tree-sha1 = "e5333cd1e1c713ee21d07b6ed8b0d8853fabe650"
+git-tree-sha1 = "bdb1942cd4c45e3c678fd11569d5cccd80976237"
 uuid = "4e289a0a-7415-4d19-859d-a7e5c4648b56"
-version = "1.0.3"
+version = "1.0.4"
 
 [[deps.Ferrite]]
 deps = ["EnumX", "LinearAlgebra", "NearestNeighbors", "Preferences", "Reexport", "SparseArrays", "Tensors", "WriteVTK"]
-git-tree-sha1 = "e0764c42a319d9374f0711468b338610aeebadf4"
+git-tree-sha1 = "a31b9d4dd58e00686e5da175dab11667af3108b6"
 uuid = "c061ca5d-56c9-439f-9c0e-210fe06d3992"
-version = "0.3.9"
+version = "0.3.14"
 
 [[deps.FerriteAssembly]]
 deps = ["Ferrite", "ForwardDiff"]
 path = ".."
 uuid = "fd21fc07-c509-4fe1-9468-19963fd5935d"
-version = "0.1.0"
+version = "0.2.0"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[deps.FillArrays]]
 deps = ["LinearAlgebra", "Random", "SparseArrays", "Statistics"]
-git-tree-sha1 = "802bfc139833d2ba893dd9e62ba1767c88d708ae"
+git-tree-sha1 = "fc86b4fd3eff76c3ce4f5e96e2fdfa6282722885"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.13.5"
+version = "1.0.0"
 
 [[deps.ForwardDiff]]
 deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
-git-tree-sha1 = "10fa12fe96e4d76acfa738f4df2126589a67374f"
+git-tree-sha1 = "00e252f4d706b3d55a8863432e742bf5717b498d"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.33"
+version = "0.10.35"
 
 [[deps.IOCapture]]
 deps = ["Logging", "Random"]
@@ -148,9 +148,9 @@ uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
 version = "0.1.8"
 
 [[deps.IrrationalConstants]]
-git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
+git-tree-sha1 = "630b497eafcc20001bba38a4651b327dcfc491d2"
 uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
-version = "0.1.1"
+version = "0.2.2"
 
 [[deps.JLLWrappers]]
 deps = ["Preferences"]
@@ -188,9 +188,9 @@ uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[deps.Libiconv_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "42b62845d70a619f063a7da093d995ec8e15e778"
+git-tree-sha1 = "c7cb1f5d892775ba13767a87c7ada0b980ea0a71"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.16.1+1"
+version = "1.16.1+2"
 
 [[deps.LightXML]]
 deps = ["Libdl", "XML2_jll"]
@@ -210,9 +210,9 @@ version = "2.14.0"
 
 [[deps.LogExpFunctions]]
 deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "94d9c52ca447e23eac0c0f074effbcd38830deb5"
+git-tree-sha1 = "0a1b7c2863e44523180fdb3146534e265a91870b"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.18"
+version = "0.3.23"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -229,11 +229,11 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[deps.MaterialModelsBase]]
 deps = ["StaticArrays", "Tensors"]
-git-tree-sha1 = "521e0f70b85826ba90bedd1f9df16562938d2ab0"
+git-tree-sha1 = "15848bbfbb4b4dc95035b652533aec17215aacb1"
 repo-rev = "main"
 repo-url = "git@github.com:KnutAM/MaterialModelsBase.jl.git"
 uuid = "af893363-701d-44dc-8b1e-d9a2c129bfc9"
-version = "0.1.2"
+version = "0.1.3"
 
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -249,15 +249,15 @@ version = "2022.2.1"
 
 [[deps.NaNMath]]
 deps = ["OpenLibm_jll"]
-git-tree-sha1 = "a7c3d1da1189a1c2fe843a3bfa04d18d20eb3211"
+git-tree-sha1 = "0877504529a3e5c3343c6f8b4c0381e57e4387e4"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
-version = "1.0.1"
+version = "1.0.2"
 
 [[deps.NearestNeighbors]]
 deps = ["Distances", "StaticArrays"]
-git-tree-sha1 = "440165bf08bc500b8fe4a7be2dc83271a00c0716"
+git-tree-sha1 = "2c3726ceb3388917602169bed973dbc97f1b51a8"
 uuid = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
-version = "0.4.12"
+version = "0.4.13"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
@@ -280,10 +280,10 @@ uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 version = "0.5.5+0"
 
 [[deps.Parsers]]
-deps = ["Dates"]
-git-tree-sha1 = "6c01a9b494f6d2a9fc180a08b182fcb06f0958a0"
+deps = ["Dates", "SnoopPrecompile"]
+git-tree-sha1 = "478ac6c952fddd4399e71d4779797c538d0ff2bf"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.4.2"
+version = "2.5.8"
 
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
@@ -322,12 +322,19 @@ uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 version = "0.7.0"
 
 [[deps.SIMD]]
-git-tree-sha1 = "7dbc15af7ed5f751a82bf3ed37757adf76c32402"
+deps = ["SnoopPrecompile"]
+git-tree-sha1 = "8b20084a97b004588125caebf418d8cab9e393d1"
 uuid = "fdea26ae-647d-5447-a871-4b548cad5224"
-version = "3.4.1"
+version = "3.4.4"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.SnoopPrecompile]]
+deps = ["Preferences"]
+git-tree-sha1 = "e760a70afdcd461cf01a575947738d359234665c"
+uuid = "66db9d55-30c0-4569-8b51-7e840670fc0c"
+version = "1.0.3"
 
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
@@ -338,15 +345,15 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[deps.SpecialFunctions]]
 deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
-git-tree-sha1 = "d75bda01f8c31ebb72df80a46c88b25d1c79c56d"
+git-tree-sha1 = "ef28127915f4229c971eb43f3fc075dd3fe91880"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "2.1.7"
+version = "2.2.0"
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "Random", "StaticArraysCore", "Statistics"]
-git-tree-sha1 = "f86b3a049e5d05227b10e15dbb315c5b90f14988"
+git-tree-sha1 = "b8d897fe7fa688e93aef573711cb207c08c9e11e"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.9"
+version = "1.5.19"
 
 [[deps.StaticArraysCore]]
 git-tree-sha1 = "6b7ba252635a5eff6a0b0664a41ee140a1c9e72a"
@@ -359,9 +366,9 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[deps.StatsAPI]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "f9af7f195fb13589dd2e2d57fdb401717d2eb1f6"
+git-tree-sha1 = "45a7769a04a3cf80da1c1c7c60caf932e6f4c9f7"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
-version = "1.5.0"
+version = "1.6.0"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -374,10 +381,10 @@ uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 version = "1.10.1"
 
 [[deps.Tensors]]
-deps = ["ForwardDiff", "LinearAlgebra", "SIMD", "StaticArrays", "Statistics"]
-git-tree-sha1 = "c35a4666a7b0aa7e0c30c7957d9de39f17b19d39"
+deps = ["ForwardDiff", "LinearAlgebra", "SIMD", "SnoopPrecompile", "StaticArrays", "Statistics"]
+git-tree-sha1 = "71f054343e85ab1eab12bf8336004309002ff82d"
 uuid = "48a634ad-e948-5137-8d70-aa71f2a747f4"
-version = "1.13.0"
+version = "1.13.1"
 
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
@@ -385,9 +392,9 @@ uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[deps.TranscodingStreams]]
 deps = ["Random", "Test"]
-git-tree-sha1 = "8a75929dcd3c38611db2f8d08546decb514fcadf"
+git-tree-sha1 = "94f38103c984f89cf77c402f2a68dbd870f8165f"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
-version = "0.9.9"
+version = "0.9.11"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
@@ -396,17 +403,22 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
+[[deps.VTKBase]]
+git-tree-sha1 = "c2d0db3ef09f1942d08ea455a9e252594be5f3b6"
+uuid = "4004b06d-e244-455f-a6ce-a5f9919cc534"
+version = "1.0.1"
+
 [[deps.WriteVTK]]
-deps = ["Base64", "CodecZlib", "FillArrays", "LightXML", "TranscodingStreams"]
-git-tree-sha1 = "f50c47d715199601a54afdd5267f24c8174842ae"
+deps = ["Base64", "CodecZlib", "FillArrays", "LightXML", "TranscodingStreams", "VTKBase"]
+git-tree-sha1 = "7b46936613e41cfe1c6a5897d243ddcab8feabec"
 uuid = "64499a7a-5c06-52f2-abe2-ccb03c286192"
-version = "1.16.0"
+version = "1.18.0"
 
 [[deps.XML2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "58443b63fb7e465a8a7210828c91c08b92132dff"
+git-tree-sha1 = "93c41695bc1c08c46c5899f4fe06d6ead504bb73"
 uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
-version = "2.9.14+0"
+version = "2.10.3+0"
 
 [[deps.Zlib_jll]]
 deps = ["Libdl"]

--- a/docs/src/firstexample_literate.jl
+++ b/docs/src/firstexample_literate.jl
@@ -3,7 +3,7 @@
 # First we create the dofhandler and cellvalues as in 
 # [`Ferrite.jl`'s heat equation example](https://ferrite-fem.github.io/Ferrite.jl/stable/examples/heat_equation/)
 using Ferrite, FerriteAssembly, BenchmarkTools
-dh = DofHandler(generate_grid(Quadrilateral, (100, 100))); push!(dh, :u, 1); close!(dh)
+dh = DofHandler(generate_grid(Quadrilateral, (100, 100))); add!(dh, :u, 1); close!(dh)
 cellvalues = CellScalarValues(QuadratureRule{2, RefCube}(2), Lagrange{2, RefCube, 1}());
 
 # We start by defining the material 

--- a/docs/src/literate/mixed_materials.jl
+++ b/docs/src/literate/mixed_materials.jl
@@ -37,7 +37,7 @@ materials = Dict(
 grid = generate_grid(Tetrahedron, (20,2,4), zero(Vec{3}), Vec((10.0,1.0,1.0)));
 cellvalues = CellVectorValues(
     QuadratureRule{3,RefTetrahedron}(2), Lagrange{3, RefTetrahedron, 1}());
-dh = DofHandler(grid); push!(dh, :u, 3); close!(dh); # Create dofhandler
+dh = DofHandler(grid); add!(dh, :u, 3); close!(dh); # Create dofhandler
 K = create_sparsity_pattern(dh);
 r = zeros(ndofs(dh));
 

--- a/docs/src/literate/plasticity.jl
+++ b/docs/src/literate/plasticity.jl
@@ -15,7 +15,7 @@ material = J2Plasticity(200.0e9, 0.3, 200.0e6, 10.0e9);
 grid = generate_grid(Tetrahedron, (20,2,4), zero(Vec{3}), Vec((10.0,1.0,1.0)));
 cellvalues = CellVectorValues(
     QuadratureRule{3,RefTetrahedron}(2), Lagrange{3, RefTetrahedron, 1}());
-dh = DofHandler(grid); push!(dh, :u, 3); close!(dh); # Create dofhandler
+dh = DofHandler(grid); add!(dh, :u, 3); close!(dh); # Create dofhandler
 K = create_sparsity_pattern(dh);
 r = zeros(ndofs(dh));
 

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -150,17 +150,17 @@ end
 function ad_error(e, Ke, re, state, ae, material, cellvalues, dh_fh, Δt, buffer)
     if isa(e, MethodError)
         if e.f === element_residual!
-            println("Could not find a correctly defined `element_residual!` method")
-            showerror(Base.stderr, MethodError(element_routine!, 
+            println(stderr, "Could not find a correctly defined `element_residual!` method")
+            showerror(stderr, MethodError(element_routine!, 
                 (Ke, re, state, ae, material, cellvalues, dh_fh, Δt, buffer))
                 ); println()
-            println("Tried to do automatic differentiation to get Ke,")
-            println("but could not find a correctly defined `element_residual!` either")
-            showerror(Base.stderr, e); println()
+            println(stderr, "Tried to do automatic differentiation to get Ke,")
+            println(stderr, "but could not find a correctly defined `element_residual!` either")
+            showerror(stderr, e); println()
             throw(ErrorException("Did not find correctly defined element_routine! or element_residual!"))
         else
-            println("If the following error is related to converting objects with `ForwardDiff.Dual`s")
-            println("entries into objects with regular numbers, please consult the docs of `element_residual!`")
+            println(stderr, "If the following error is related to converting objects with `ForwardDiff.Dual`s")
+            println(stderr, "entries into objects with regular numbers, please consult the docs of `element_residual!`")
         end
     end
     rethrow()

--- a/test/heatequation.jl
+++ b/test/heatequation.jl
@@ -11,7 +11,7 @@
     function get_dh()
         grid = get_grid();
         dh = DofHandler(grid)
-        push!(dh, :u, 1)
+        add!(dh, :u, 1)
         close!(dh);
         return dh
     end
@@ -19,7 +19,7 @@
     function get_mdh(ip)
         grid = get_grid();
         dh = MixedDofHandler(grid)
-        push!(dh, FieldHandler([Field(:u, ip, 1)], Set(collect(1:getncells(grid)))))
+        add!(dh, FieldHandler([Field(:u, ip, 1)], Set(collect(1:getncells(grid)))))
         close!(dh);
         return dh
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ include("heatequation.jl")
 
 
 @testset "Errors" begin
-    @info("Start of expected error messages. These are expected and ok if tests pass!")
+    printstyled("=== Testing will give expected error messages, ok if tests pass! ===\n"; color=:green, bold=true)
     grid = generate_grid(Quadrilateral, (2,2))
     dh = DofHandler(grid); add!(dh, :u, 1); close!(dh)
     cv = CellScalarValues(QuadratureRule{2, RefCube}(2), Lagrange{2, RefCube, 1}());
@@ -45,7 +45,7 @@ include("heatequation.jl")
             @test_throws DimensionMismatch doassemble!(as, cb, states, dh, colors, a)
         end
     end
-    @info("End of expected error messages")
+    printstyled("================== End of expected error messages ==================\n"; color=:green, bold=true)
 end
 
 # Print show warning at the end if running tests single-threaded. 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,50 +3,49 @@ using SparseArrays
 using Test
 import FerriteAssembly as FA
 
-@testset "FerriteAssembly.jl" begin
-    include("heatequation.jl")
+include("states.jl")
+include("heatequation.jl")
 
-    @testset "Errors" begin
-        @info("Start of expected error messages. These are expected and ok if tests pass!")
-        grid = generate_grid(Quadrilateral, (2,2))
-        dh = DofHandler(grid); push!(dh, :u, 1); close!(dh)
-        cv = CellScalarValues(QuadratureRule{2, RefCube}(2), Lagrange{2, RefCube, 1}());
-        states = create_states(dh)
-        K = create_sparsity_pattern(dh)
-        r = zeros(ndofs(dh))
-        a = zeros(ndofs(dh))
-        # Check error when element_residual! is not defined. 
-        cb = setup_cellbuffer(dh, cv, nothing)    # material=nothing not supported
-        cb_ad = setup_ad_cellbuffer(states, dh, cv, nothing)
-        exception = ErrorException("Did not find correctly defined element_routine! or element_residual!")
-        @test_throws exception doassemble!(start_assemble(K,r), cb, states, dh, a)
-        @test_throws exception doassemble!(start_assemble(K,r), cb_ad, states, dh, a)
-        
-        # Check error when trying to insert a dual number into the state variables
-        # Note: Not optimal as we should actually check the printed message
-        states_dualissue = create_states(dh, Returns(0.0), cv)
-        struct _TestMaterial end 
-        
-        function FerriteAssembly.element_residual!(re, state, ae, m::_TestMaterial, args...)
-            state[1] = first(ae) # Not allowed, must be state[1] = ForwardDiff.value(first(ae))
-        end
-        cb_dualissue = setup_ad_cellbuffer(states_dualissue, dh, cv, _TestMaterial())
-        @test_throws MethodError doassemble!(start_assemble(K,r), cb_dualissue, states_dualissue, dh, a) 
 
-        # Check that error thrown for mismatch between parallel buffer sizes and number of threads 
-        if Threads.nthreads() > 1 # The following test will fail unless running more than one thread
-            cellbuffers = create_threaded_CellBuffers(cb)
-            assemblers = create_threaded_assemblers(K, r)
-            cellbuffers_n1 = create_threaded_CellBuffers(cb; nthreads=1)
-            assemblers_n1 = create_threaded_assemblers(K, r; nthreads=1)
-            colors = create_coloring(dh.grid)
-            for (as,cb) in ((assemblers_n1, cellbuffers_n1), (assemblers_n1, cellbuffers), (assemblers, cellbuffers_n1))
-                @test_throws DimensionMismatch doassemble!(as, cb, states, dh, colors, a)
-            end
-        end
-        @info("End of expected error messages")
+@testset "Errors" begin
+    @info("Start of expected error messages. These are expected and ok if tests pass!")
+    grid = generate_grid(Quadrilateral, (2,2))
+    dh = DofHandler(grid); push!(dh, :u, 1); close!(dh)
+    cv = CellScalarValues(QuadratureRule{2, RefCube}(2), Lagrange{2, RefCube, 1}());
+    states = create_states(dh)
+    K = create_sparsity_pattern(dh)
+    r = zeros(ndofs(dh))
+    a = zeros(ndofs(dh))
+    # Check error when element_residual! is not defined. 
+    cb = setup_cellbuffer(dh, cv, nothing)    # material=nothing not supported
+    cb_ad = setup_ad_cellbuffer(states, dh, cv, nothing)
+    exception = ErrorException("Did not find correctly defined element_routine! or element_residual!")
+    @test_throws exception doassemble!(start_assemble(K,r), cb, states, dh, a)
+    @test_throws exception doassemble!(start_assemble(K,r), cb_ad, states, dh, a)
+    
+    # Check error when trying to insert a dual number into the state variables
+    # Note: Not optimal as we should actually check the printed message
+    states_dualissue = create_states(dh, Returns(0.0), cv)
+    struct _TestMaterial end 
+    
+    function FerriteAssembly.element_residual!(re, state, ae, m::_TestMaterial, args...)
+        state[1] = first(ae) # Not allowed, must be state[1] = ForwardDiff.value(first(ae))
     end
+    cb_dualissue = setup_ad_cellbuffer(states_dualissue, dh, cv, _TestMaterial())
+    @test_throws MethodError doassemble!(start_assemble(K,r), cb_dualissue, states_dualissue, dh, a) 
 
+    # Check that error thrown for mismatch between parallel buffer sizes and number of threads 
+    if Threads.nthreads() > 1 # The following test will fail unless running more than one thread
+        cellbuffers = create_threaded_CellBuffers(cb)
+        assemblers = create_threaded_assemblers(K, r)
+        cellbuffers_n1 = create_threaded_CellBuffers(cb; nthreads=1)
+        assemblers_n1 = create_threaded_assemblers(K, r; nthreads=1)
+        colors = create_coloring(dh.grid)
+        for (as,cb) in ((assemblers_n1, cellbuffers_n1), (assemblers_n1, cellbuffers), (assemblers, cellbuffers_n1))
+            @test_throws DimensionMismatch doassemble!(as, cb, states, dh, colors, a)
+        end
+    end
+    @info("End of expected error messages")
 end
 
 # Print show warning at the end if running tests single-threaded. 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ include("heatequation.jl")
 @testset "Errors" begin
     @info("Start of expected error messages. These are expected and ok if tests pass!")
     grid = generate_grid(Quadrilateral, (2,2))
-    dh = DofHandler(grid); push!(dh, :u, 1); close!(dh)
+    dh = DofHandler(grid); add!(dh, :u, 1); close!(dh)
     cv = CellScalarValues(QuadratureRule{2, RefCube}(2), Lagrange{2, RefCube, 1}());
     states = create_states(dh)
     K = create_sparsity_pattern(dh)

--- a/test/states.jl
+++ b/test/states.jl
@@ -1,0 +1,34 @@
+@testset "state variables" begin
+    # Defs
+    struct MatStateTest{T}
+        A::Matrix{T}
+    end
+    struct StateTest
+        c::Int
+    end
+    FA.create_cell_state(::MatStateTest, cv, args...) = [StateTest(0) for _ in 1:getnquadpoints(cv)]
+    function FA.element_residual!(re, states::Vector{StateTest}, ae, m::MatStateTest, cv, args...)
+        re .= m.A*ae
+        for i in 1:getnquadpoints(cv)
+            states[i] = StateTest(states[i].c + 1)
+        end
+    end
+    for (CT, Dim) in ((Line, 1), (QuadraticTriangle, 2), (Hexahedron, 3))
+        grid = generate_grid(CT, ntuple(_->1, Dim))
+        dh = DofHandler(grid); add!(dh, :u, Dim); close!(dh);
+        ndpc = Ferrite.ndofs_per_cell(dh); 
+        mat=MatStateTest(rand(ndpc,ndpc));
+        K = create_sparsity_pattern(dh)
+        r = zeros(ndofs(dh));
+        a = copy(r)
+        ip = Ferrite.default_interpolation(getcelltype(grid))
+        RefShape = Ferrite.getrefshape(ip)
+        cv = CellVectorValues(QuadratureRule{Dim,RefShape}(2), ip);
+        states = FA.create_states(dh, mat, cv);
+        cellbuffer = FA.setup_cellbuffer(dh, cv, mat);
+        assembler = start_assemble(K,r)
+        FA.doassemble!(assembler, cellbuffer, states, dh, a);
+        @show ndpc
+        @test first(first(states)).c == 1
+    end
+end

--- a/test/states.jl
+++ b/test/states.jl
@@ -28,7 +28,9 @@
         cellbuffer = FA.setup_cellbuffer(dh, cv, mat);
         assembler = start_assemble(K,r)
         FA.doassemble!(assembler, cellbuffer, states, dh, a);
-        @show ndpc
         @test first(first(states)).c == 1
+        cellbuffer_ad = FA.setup_ad_cellbuffer(states, dh, cv, mat)
+        FA.doassemble!(assembler, cellbuffer_ad, states, dh, a);
+        @test first(first(states)).c == 2
     end
 end


### PR DESCRIPTION
xref #9, but keep this open as the current solution should be considered temporary, and consider to use a safer approach suggested in that issue (old and new state inputs, but that should be kept for next major release, this is just fixing the current bug)