### PR TITLE
Kam/spawned

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.3.1"
 Ferrite = "c061ca5d-56c9-439f-9c0e-210fe06d3992"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 MaterialModelsBase = "af893363-701d-44dc-8b1e-d9a2c129bfc9"
+ThreadPinning = "811555cd-349b-4f26-b7bc-1f208b848042"
 
 [compat]
 Ferrite = "0.3.11"

--- a/bench_julia_threads.sh
+++ b/bench_julia_threads.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#SBATCH --partition=standard  # Partition (queue), some alt: standard, shortrun_large, shortrun_small, testing, fat, gpu01queue, gpu02queue, gpu03queue
+#SBATCH -N 1                  # Number of nodes
+#SBATCH -n 20                 # Number of processes
+#SBATCH --time=0-01:00:00     # Time (1h default)
+# Start a job by calling 
+# `sbatch <sbatch_options> <path/to/run_julia.sh> -s <path/to/julia/script.jl>`
+# from the folder containing the Project.toml
+# The sbatch options are any options available for the currently used sbatch, and will override settings in this file
+# An example call could be 
+# sbatch -J myjob -n 2 --time=2-00:00:00 $SBATCH_SCRIPTS/run_julia.sh -s runsim.jl
+# Assuming that the environment variable $SBATCH_SCRIPTS contains the path to the `sbatch` folder
+# Here, the job name is set to "myjob", the number of processors to 2, and the time limit to 2 days
+
+
+# Get input options
+while getopts ":s:" opt; do
+  case $opt in
+    s)
+      script=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z $script ]; then
+    echo "No script file given, this is mandatory!"
+    exit 1
+fi
+
+# Build environment
+julia --project=. --threads $SLURM_NPROCS -e 'using Pkg; Pkg.instantiate()'
+
+# Run benchmark
+echo "Threads = 1"
+julia --project=. --threads 1 $script
+
+echo "Threads = 2"
+julia --project=. --threads 2 $script
+
+echo "Threads = 4"
+julia --project=. --threads 4 $script
+
+echo "Threads = 8"
+julia --project=. --threads 8 $script
+
+echo "Threads = 16"
+julia --project=. --threads 16 $script

--- a/benchmarks/dennis.jl
+++ b/benchmarks/dennis.jl
@@ -1,0 +1,192 @@
+using Ferrite, SparseArrays
+
+using ThreadPinning
+pinthreads(:cores)
+
+function create_colored_cantilever_grid(celltype, n)
+    grid = generate_grid(celltype, (10*n, n, n), Vec{3}((0.0, 0.0, 0.0)), Vec{3}((10.0, 1.0, 1.0)))
+    colors = create_coloring(grid)
+    return grid, colors
+end;
+
+# #### DofHandler
+function create_dofhandler(grid::Grid{dim}) where {dim}
+    dh = DofHandler(grid)
+    push!(dh, :u, dim) # Add a displacement field
+    close!(dh)
+end;
+
+# ### Stiffness tensor for linear elasticity
+function create_stiffness(::Val{dim}) where {dim}
+    E = 200e9
+    ν = 0.3
+    λ = E*ν / ((1+ν) * (1 - 2ν))
+    μ = E / (2(1+ν))
+    δ(i,j) = i == j ? 1.0 : 0.0
+    g(i,j,k,l) = λ*δ(i,j)*δ(k,l) + μ*(δ(i,k)*δ(j,l) + δ(i,l)*δ(j,k))
+    C = SymmetricTensor{4, dim}(g);
+    return C
+end;
+
+# ## Threaded data structures
+#
+# ScratchValues is a thread-local collection of data that each thread needs to own,
+# since we need to be able to mutate the data in the threads independently
+struct ScratchValues{T, CV <: CellValues, FV <: FaceValues, TT <: AbstractTensor, dim, Ti}
+    Ke::Matrix{T}
+    fe::Vector{T}
+    cellvalues::CV
+    facevalues::FV
+    global_dofs::Vector{Int}
+    ɛ::Vector{TT}
+    coordinates::Vector{Vec{dim, T}}
+    assembler::Ferrite.AssemblerSparsityPattern{T, Ti}
+end;
+
+# Each thread need its own CellValues and FaceValues (although, for this example we don't use
+# the FaceValues)
+function create_values(refshape, dim, order::Int)
+    ## Interpolations and values
+    interpolation_space = Lagrange{dim, refshape, 1}()
+    quadrature_rule = QuadratureRule{dim, refshape}(order)
+    face_quadrature_rule = QuadratureRule{dim-1, refshape}(order)
+    cellvalues = [CellVectorValues(quadrature_rule, interpolation_space) for i in 1:Threads.nthreads()];
+    facevalues = [FaceVectorValues(face_quadrature_rule, interpolation_space) for i in 1:Threads.nthreads()];
+    return cellvalues, facevalues
+end;
+
+# Create a `ScratchValues` for each thread with the thread local data
+function create_scratchvalues(K, f, dh::DofHandler{dim}) where {dim}
+    nthreads = Threads.nthreads()
+    assemblers = [start_assemble(K, f) for i in 1:nthreads]
+    cellvalues, facevalues = create_values(RefCube, dim, 2)
+
+    n_basefuncs = getnbasefunctions(cellvalues[1])
+    global_dofs = [zeros(Int, ndofs_per_cell(dh)) for i in 1:nthreads]
+
+    fes = [zeros(n_basefuncs) for i in 1:nthreads] # Local force vector
+    Kes = [zeros(n_basefuncs, n_basefuncs) for i in 1:nthreads]
+
+    ɛs = [[zero(SymmetricTensor{2, dim}) for i in 1:n_basefuncs] for i in 1:nthreads]
+
+    coordinates = [[zero(Vec{dim}) for i in 1:length(dh.grid.cells[1].nodes)] for i in 1:nthreads]
+
+    return [ScratchValues(Kes[i], fes[i], cellvalues[i], facevalues[i], global_dofs[i],
+                         ɛs[i], coordinates[i], assemblers[i]) for i in 1:nthreads]
+end;
+
+# ## Threaded assemble
+
+# The assembly function loops over each color and does a threaded assembly for that color
+function doassemble(K::SparseMatrixCSC, colors, grid::Grid, dh::DofHandler, C::SymmetricTensor{4, dim}, f::Vector{Float64}, scratches::Vector{SV}, b::Vec{dim}) where {dim, SV}
+    ## Each color is safe to assemble threaded
+    for color in colors
+        ## We try to equipartition the array to increase load per task.
+        chunk_size = max(1, 1 + length(color) ÷ Threads.nthreads())
+        color_partition = [color[i:min(i + chunk_size - 1, end)] for i in 1:chunk_size:length(color)]
+        ## Now we should have a 1:1 correspondence between tasks and elements to assemble.
+        Threads.@threads :static for i in 1:length(color_partition)
+            for cellid ∈ color_partition[i]
+                assemble_cell!(scratches[i], cellid, K, grid, dh, C, b)
+            end
+        end
+    end
+
+    return K, f
+end
+
+# The cell assembly function is written the same way as if it was a single threaded example.
+# The only difference is that we unpack the variables from our `scratch`.
+function assemble_cell!(scratch::ScratchValues, cell::Int, K::SparseMatrixCSC,
+                        grid::Grid, dh::DofHandler, C::SymmetricTensor{4, dim}, b::Vec{dim}) where {dim}
+
+    ## Unpack our stuff from the scratch
+    Ke, fe, cellvalues, facevalues, global_dofs, ɛ, coordinates, assembler =
+         scratch.Ke, scratch.fe, scratch.cellvalues, scratch.facevalues,
+         scratch.global_dofs, scratch.ɛ, scratch.coordinates, scratch.assembler
+
+    fill!(Ke, 0)
+    fill!(fe, 0)
+
+    n_basefuncs = getnbasefunctions(cellvalues)
+
+    ## Fill up the coordinates
+    nodeids = grid.cells[cell].nodes
+    for j in 1:length(coordinates)
+        coordinates[j] = grid.nodes[nodeids[j]].x
+    end
+
+    reinit!(cellvalues, coordinates)
+
+    for q_point in 1:getnquadpoints(cellvalues)
+        for i in 1:n_basefuncs
+            ɛ[i] = symmetric(shape_gradient(cellvalues, q_point, i))
+        end
+        dΩ = getdetJdV(cellvalues, q_point)
+        for i in 1:n_basefuncs
+            δu = shape_value(cellvalues, q_point, i)
+            fe[i] += (δu ⋅ b) * dΩ
+            ɛC = ɛ[i] ⊡ C
+            for j in 1:n_basefuncs
+                Ke[i, j] += (ɛC ⊡ ɛ[j]) * dΩ
+            end
+        end
+    end
+
+    celldofs!(global_dofs, dh, cell)
+    assemble!(assembler, global_dofs, fe, Ke)
+end;
+#= LIKWID not possible on cluster?
+function run_assemble_perf(n = 30)
+    refshape = RefCube
+    quadrature_order = 2
+    dim = 3
+    
+    grid, colors = create_colored_cantilever_grid(Hexahedron, n);
+    dh = create_dofhandler(grid);
+
+    K = create_sparsity_pattern(dh);
+    C = create_stiffness(Val{3}());
+    f = zeros(ndofs(dh))
+    scratches = create_scratchvalues(K, f, dh)
+    b = Vec{3}((0.0, 0.0, 0.0))
+    ## compilation
+    doassemble(K, colors, grid, dh, C, f, scratches, b);
+    return @perfmon "FLOPS_DP" doassemble(K, colors, grid, dh, C, f, scratches, b);
+end
+
+metrics, events = run_assemble_perf();
+clocks = [res["Clock [MHz]"] for res in metrics["FLOPS_DP"]]
+println("Clock [MHz] (min, avg, max): ", minimum(clocks), " | ", mean(clocks), " | " , maximum(clocks)) 
+
+thread_times = [res["Runtime unhalted [s]"] for res in metrics["FLOPS_DP"]]
+println("Runtime unhalted [s] (min, avg, max): ", minimum(thread_times), " | ", mean(thread_times), " | " , maximum(thread_times))
+
+println("Total runtime [s] ", first([res["Runtime (RDTSC) [s]"] for res in metrics["FLOPS_DP"]]))
+=#
+
+function run_assemble(n = 20)
+    refshape = RefCube
+    quadrature_order = 2
+    dim = 3
+    
+    grid, colors = create_colored_cantilever_grid(Hexahedron, n);
+    dh = create_dofhandler(grid);
+
+    K = create_sparsity_pattern(dh);
+    C = create_stiffness(Val{3}());
+    f = zeros(ndofs(dh))
+    scratches = create_scratchvalues(K, f, dh)
+    b = Vec{3}((0.0, 0.0, 0.0))
+    ## compilation
+    doassemble(K, colors, grid, dh, C, f, scratches, b);
+
+    b = @elapsed @time K, f = doassemble(K, colors, grid, dh, C, f, scratches, b);
+    return b
+end
+
+open("bench_thread_dennis.log"; append=true) do fid
+    for _ in 1:3
+        write(fid, "$(Threads.nthreads()), $(run_assemble())\n")
+    end
+end

--- a/benchmarks/ferrite_example.jl
+++ b/benchmarks/ferrite_example.jl
@@ -1,0 +1,159 @@
+using Ferrite, SparseArrays
+
+function create_example_2d_grid()
+    grid = generate_grid(Quadrilateral, (10, 10), Vec{2}((0.0, 0.0)), Vec{2}((10.0, 10.0)))
+    colors_workstream = create_coloring(grid; alg=ColoringAlgorithm.WorkStream)
+    colors_greedy = create_coloring(grid; alg=ColoringAlgorithm.Greedy)
+    vtk_grid("colored", grid) do vtk
+        vtk_cell_data_colors(vtk, colors_workstream, "workstream-coloring")
+        vtk_cell_data_colors(vtk, colors_greedy, "greedy-coloring")
+    end
+end
+
+create_example_2d_grid();
+
+function create_colored_cantilever_grid(celltype, n)
+    grid = generate_grid(celltype, (10*n, n, n), Vec{3}((0.0, 0.0, 0.0)), Vec{3}((10.0, 1.0, 1.0)))
+    colors = create_coloring(grid)
+    return grid, colors
+end;
+
+function create_dofhandler(grid::Grid{dim}) where {dim}
+    dh = DofHandler(grid)
+    add!(dh, :u, dim) # Add a displacement field
+    close!(dh)
+end;
+
+function create_stiffness(::Val{dim}) where {dim}
+    E = 200e9
+    ν = 0.3
+    λ = E*ν / ((1+ν) * (1 - 2ν))
+    μ = E / (2(1+ν))
+    δ(i,j) = i == j ? 1.0 : 0.0
+    g(i,j,k,l) = λ*δ(i,j)*δ(k,l) + μ*(δ(i,k)*δ(j,l) + δ(i,l)*δ(j,k))
+    C = SymmetricTensor{4, dim}(g);
+    return C
+end;
+
+struct ScratchValues{T, CV <: CellValues, FV <: FaceValues, TT <: AbstractTensor, dim, Ti}
+    Ke::Matrix{T}
+    fe::Vector{T}
+    cellvalues::CV
+    facevalues::FV
+    global_dofs::Vector{Int}
+    ɛ::Vector{TT}
+    coordinates::Vector{Vec{dim, T}}
+    assembler::Ferrite.AssemblerSparsityPattern{T, Ti}
+end;
+
+function create_values(refshape, dim, order::Int)
+    # Interpolations and values
+    interpolation_space = Lagrange{dim, refshape, 1}()
+    quadrature_rule = QuadratureRule{dim, refshape}(order)
+    face_quadrature_rule = QuadratureRule{dim-1, refshape}(order)
+    cellvalues = [CellVectorValues(quadrature_rule, interpolation_space) for i in 1:Threads.nthreads()];
+    facevalues = [FaceVectorValues(face_quadrature_rule, interpolation_space) for i in 1:Threads.nthreads()];
+    return cellvalues, facevalues
+end;
+
+function create_scratchvalues(K, f, dh::DofHandler{dim}) where {dim}
+    nthreads = Threads.nthreads()
+    assemblers = [start_assemble(K, f) for i in 1:nthreads]
+    cellvalues, facevalues = create_values(RefCube, dim, 2)
+
+    n_basefuncs = getnbasefunctions(cellvalues[1])
+    global_dofs = [zeros(Int, ndofs_per_cell(dh)) for i in 1:nthreads]
+
+    fes = [zeros(n_basefuncs) for i in 1:nthreads] # Local force vector
+    Kes = [zeros(n_basefuncs, n_basefuncs) for i in 1:nthreads]
+
+    ɛs = [[zero(SymmetricTensor{2, dim}) for i in 1:n_basefuncs] for i in 1:nthreads]
+
+    coordinates = [[zero(Vec{dim}) for i in 1:length(dh.grid.cells[1].nodes)] for i in 1:nthreads]
+
+    return [ScratchValues(Kes[i], fes[i], cellvalues[i], facevalues[i], global_dofs[i],
+                         ɛs[i], coordinates[i], assemblers[i]) for i in 1:nthreads]
+end;
+
+function doassemble(K::SparseMatrixCSC, colors, grid::Grid, dh::DofHandler, C::SymmetricTensor{4, dim}) where {dim}
+
+    f = zeros(ndofs(dh))
+    scratches = create_scratchvalues(K, f, dh)
+    b = Vec{3}((0.0, 0.0, 0.0)) # Body force
+
+    for color in colors
+        # Each color is safe to assemble threaded
+        Threads.@threads :static for i in 1:length(color)
+            assemble_cell!(scratches[Threads.threadid()], color[i], K, grid, dh, C, b)
+        end
+    end
+
+    return K, f
+end
+
+function assemble_cell!(scratch::ScratchValues, cell::Int, K::SparseMatrixCSC,
+                        grid::Grid, dh::DofHandler, C::SymmetricTensor{4, dim}, b::Vec{dim}) where {dim}
+
+    # Unpack our stuff from the scratch
+    Ke, fe, cellvalues, facevalues, global_dofs, ɛ, coordinates, assembler =
+         scratch.Ke, scratch.fe, scratch.cellvalues, scratch.facevalues,
+         scratch.global_dofs, scratch.ɛ, scratch.coordinates, scratch.assembler
+
+    fill!(Ke, 0)
+    fill!(fe, 0)
+
+    n_basefuncs = getnbasefunctions(cellvalues)
+
+    # Fill up the coordinates
+    nodeids = grid.cells[cell].nodes
+    for j in 1:length(coordinates)
+        coordinates[j] = grid.nodes[nodeids[j]].x
+    end
+
+    reinit!(cellvalues, coordinates)
+
+    for q_point in 1:getnquadpoints(cellvalues)
+        for i in 1:n_basefuncs
+            ɛ[i] = symmetric(shape_gradient(cellvalues, q_point, i))
+        end
+        dΩ = getdetJdV(cellvalues, q_point)
+        for i in 1:n_basefuncs
+            δu = shape_value(cellvalues, q_point, i)
+            fe[i] += (δu ⋅ b) * dΩ
+            ɛC = ɛ[i] ⊡ C
+            for j in 1:n_basefuncs
+                Ke[i, j] += (ɛC ⊡ ɛ[j]) * dΩ
+            end
+        end
+    end
+
+    celldofs!(global_dofs, dh, cell)
+    assemble!(assembler, global_dofs, fe, Ke)
+end;
+
+function run_assemble()
+    refshape = RefCube
+    quadrature_order = 2
+    dim = 3
+    n = 20
+    grid, colors = create_colored_cantilever_grid(Hexahedron, n);
+    dh = create_dofhandler(grid);
+
+    K = create_sparsity_pattern(dh);
+    C = create_stiffness(Val{3}());
+    # compilation
+    doassemble(K, colors, grid, dh, C);
+    b = @elapsed @time K, f = doassemble(K, colors, grid, dh, C);
+    return b
+end
+
+function calculate_stiffness()
+    n = 20
+    grid, colors = create_colored_cantilever_grid(Hexahedron, n);
+    dh = create_dofhandler(grid);
+
+    K = create_sparsity_pattern(dh);
+    C = create_stiffness(Val{3}());
+    doassemble(K, colors, grid, dh, C);
+    return K
+end

--- a/benchmarks/test.jl
+++ b/benchmarks/test.jl
@@ -1,0 +1,23 @@
+using Ferrite
+using FerriteAssembly
+import FerriteAssembly.ExampleElements: StationaryFourier
+
+
+function setup()
+    grid = generate_grid(Quadrilateral, (2000,2000))
+    ip = Ferrite.default_interpolation(getcelltype(grid))
+    qr = QuadratureRule{2,RefCube}(2)
+    dh = DofHandler(grid); add!(dh, :u, 1, ip); close!(dh)
+    cv = CellScalarValues(qr, ip)
+
+    buffer, new_states = setup_assembly(dh, StationaryFourier(1.0), cv; threading=Val(true))
+    K = create_sparsity_pattern(dh)
+    r = zeros(ndofs(dh))
+    
+    return K, r, new_states, buffer
+end
+
+const K_, r_, new_states_, buffer_ = setup()
+const assembler_ = start_assemble(K, r)
+@time doassemble!(assembler_, new_states_, buffer_)
+@time doassemble!(assembler_, new_states_, buffer_)

--- a/benchmarks/threaded_elasticity.jl
+++ b/benchmarks/threaded_elasticity.jl
@@ -1,0 +1,34 @@
+using Ferrite
+using FerriteAssembly
+import FerriteAssembly.ExampleElements: LinearElastic
+
+setup(threaded=Val(Threads.nthreads()>1)) = setup_threaded(threaded)
+function setup_threaded(threaded::Val)
+    grid = generate_grid(Hexahedron, (20,20,20))
+    ip = Ferrite.default_interpolation(getcelltype(grid))
+    qr = QuadratureRule{3,RefCube}(5)
+    dh = DofHandler(grid); add!(dh, :u, 3, ip); close!(dh)
+    cv = CellVectorValues(qr, ip)
+
+    buffer, new_states = setup_assembly(dh, LinearElastic(E=210e9, ν=0.3), cv; threading=threaded)
+    K = create_sparsity_pattern(dh)
+    r = zeros(ndofs(dh))
+    
+    return K, r, new_states, buffer
+end
+
+K, r, new_states, buffer = setup()
+assembler = start_assemble(K, r)
+doassemble!(assembler, new_states, buffer)
+
+#assembler = start_assemble(K, r)
+#@time doassemble!(assembler, new_states, buffer)
+
+function dotiming(K, r, new_states, buffer)
+    assembler = start_assemble(K, r)
+    @time doassemble!(assembler, new_states, buffer)
+end
+
+for i in 1:5
+    print(i, ": "); dotiming(K, r, new_states, buffer)
+end

--- a/benchmarks/threaded_elasticity.jl
+++ b/benchmarks/threaded_elasticity.jl
@@ -3,14 +3,14 @@ using FerriteAssembly
 import FerriteAssembly.ExampleElements: LinearElastic
 
 setup(threaded=Val(Threads.nthreads()>1)) = setup_threaded(threaded)
-function setup_threaded(threaded::Val)
-    grid = generate_grid(Hexahedron, (20,20,20))
+function setup_threaded(threaded::Val; n=20)
+    grid = generate_grid(Hexahedron, (10*n,n,n), zero(Vec{3}), Vec((10.0, 1.0, 1.0)))
     ip = Ferrite.default_interpolation(getcelltype(grid))
-    qr = QuadratureRule{3,RefCube}(5)
+    qr = QuadratureRule{3,RefCube}(2)
     dh = DofHandler(grid); add!(dh, :u, 3, ip); close!(dh)
     cv = CellVectorValues(qr, ip)
 
-    buffer, new_states = setup_assembly(dh, LinearElastic(E=210e9, ν=0.3), cv; threading=threaded)
+    buffer, new_states = setup_assembly(dh, LinearElastic(E=200e9, ν=0.3), cv; threading=threaded)
     K = create_sparsity_pattern(dh)
     r = zeros(ndofs(dh))
     

--- a/benchmarks/threaded_heatequation.jl
+++ b/benchmarks/threaded_heatequation.jl
@@ -1,7 +1,6 @@
 using Ferrite
 using FerriteAssembly
 import FerriteAssembly.ExampleElements: StationaryFourier
-using BenchmarkTools
 
 const THREADING = Val(Threads.nthreads()>1)
 
@@ -21,4 +20,4 @@ end
 
 K, r, new_states, buffer = setup()
 assembler = start_assemble(K, r)
-@time doassemble!(assembler, new_states, buffer)
+doassemble!(assembler, new_states, buffer)

--- a/benchmarks/threaded_heatequation.jl
+++ b/benchmarks/threaded_heatequation.jl
@@ -1,0 +1,24 @@
+using Ferrite
+using FerriteAssembly
+import FerriteAssembly.ExampleElements: StationaryFourier
+using BenchmarkTools
+
+const THREADING = Val(Threads.nthreads()>1)
+
+function setup()
+    grid = generate_grid(Quadrilateral, (2000,2000))
+    ip = Ferrite.default_interpolation(getcelltype(grid))
+    qr = QuadratureRule{2,RefCube}(2)
+    dh = DofHandler(grid); add!(dh, :u, 1, ip); close!(dh)
+    cv = CellScalarValues(qr, ip)
+
+    buffer, new_states = setup_assembly(dh, StationaryFourier(1.0), cv; threading=THREADING)
+    K = create_sparsity_pattern(dh)
+    r = zeros(ndofs(dh))
+    
+    return K, r, new_states, buffer
+end
+
+K, r, new_states, buffer = setup()
+assembler = start_assemble(K, r)
+@time doassemble!(assembler, new_states, buffer)

--- a/benchmarks/tmp.jl
+++ b/benchmarks/tmp.jl
@@ -1,0 +1,5 @@
+include(joinpath(@__DIR__, "threaded_heatequation.jl"))
+@time doassemble!(assembler, new_states, buffer)
+@time doassemble!(assembler, new_states, buffer)
+@time doassemble!(assembler, new_states, buffer)
+

--- a/src/ChunkIterator.jl
+++ b/src/ChunkIterator.jl
@@ -32,3 +32,18 @@ function Base.iterate(ci::ChunkIterator, state=nothing)
 end
 Base.length(ci::ChunkIterator) = length(ci.chunks)
 Base.eltype(::ChunkIterator{T}) where T = Vector{T}
+
+# Non-iterator implementation
+function get_chunk(ci::ChunkIterator{T}) where T
+    lock(ci)
+    try
+        if length(ci.chunks) <= ci.index
+            return T[]
+        else
+            ci.index += 1
+            return @inbounds ci.chunks[ci.index]
+        end
+    finally
+        unlock(ci)
+    end
+end

--- a/src/ChunkIterator.jl
+++ b/src/ChunkIterator.jl
@@ -1,0 +1,34 @@
+# Inspired by Base.Channel, but data is not removed, 
+# only the index is incremented. 
+mutable struct ChunkIterator{T}
+    const lock::ReentrantLock
+    const chunks::Vector{Vector{T}}
+    index::Int
+end
+ChunkIterator(chunks::Vector{<:Vector}) = ChunkIterator(ReentrantLock(), chunks, 0)
+reset!(ci::ChunkIterator) = (ci.index=0)
+
+# Base.AbstractLock interface
+Base.lock(ci::ChunkIterator) = lock(ci.lock)
+Base.lock(f, ci::ChunkIterator) = lock(f, ci.lock)
+Base.unlock(ci::ChunkIterator) = unlock(ci.lock)
+Base.trylock(ci::ChunkIterator) = trylock(ci.lock)
+
+# Iterator interface
+function Base.iterate(ci::ChunkIterator, state=nothing)
+    lock(ci)
+    local retval
+    try
+        if length(ci.chunks) <= ci.index
+            retval = nothing 
+        else
+            ci.index += 1
+            retval = (@inbounds ci.chunks[ci.index], nothing)
+        end
+    finally
+        unlock(ci)
+    end
+    return retval
+end
+Base.length(ci::ChunkIterator) = length(ci.chunks)
+Base.eltype(::ChunkIterator{T}) where T = Vector{T}

--- a/src/FerriteAssembly.jl
+++ b/src/FerriteAssembly.jl
@@ -3,6 +3,7 @@ using Ferrite, ForwardDiff
 
 include("SubDofHandler.jl") # Temporary solutions until Ferrite is updated
 include("TaskLocals.jl")    # Task-local storage model 
+include("ChunkIterator.jl") # Thread-safe iteration over chunks of cells
 include("utils.jl")
 
 include("scaling.jl")

--- a/src/assembly.jl
+++ b/src/assembly.jl
@@ -70,10 +70,10 @@ function threaded_assemble_domain!(assemblers::TaskLocals, new_states, buffer::T
     scatter!(cellbuffers)
     scatter!(assemblers)
     num_tasks = Threads.nthreads()
-    queue_length = typemax(Int)# 2*num_tasks
+    #queue_length = typemax(Int)# 2*num_tasks
     for saved_set_chunks in buffer.saved_set_chunks
-        set_chunks = Channel{Vector{Int}}(queue_length)
-        #set_chunks = ChunkIterator(saved_set_chunks)
+        #set_chunks = Channel{Vector{Int}}(queue_length)
+        set_chunks = ChunkIterator(saved_set_chunks)
         # Base.Experimental.@sync exits immediately on exception (allow Ctrl+C)
         Base.Experimental.@sync begin 
             # Expected that this first task will run until set_chunks is full.
@@ -82,7 +82,7 @@ function threaded_assemble_domain!(assemblers::TaskLocals, new_states, buffer::T
             # `set_chunk`, the thread working on that task will work on filling up the buffer again.
             # Once the first item is added, all other tasks can continue and only the one whose thread 
             # is filling up has to wait for the filling up to be completed.
-            # ChunkIterator can replace the following, but for some reason it is not faster...
+            #= ChunkIterator can replace the following, but for some reason it is not faster...
             Threads.@spawn begin
                 for set_chunk in saved_set_chunks
                     put!(set_chunks, set_chunk)

--- a/src/assembly.jl
+++ b/src/assembly.jl
@@ -63,19 +63,49 @@ function sequential_assemble_domain!(assembler, new_states, buffer; a=nothing, a
     end
 end
 
-function threaded_assemble_domain!(assembler::TaskLocals, new_states, buffer::ThreadedDomainBuffer; a=nothing, aold=nothing, old_states=nothing, Δt=NaN)
+function threaded_assemble_domain!(assemblers::TaskLocals, new_states, buffer::ThreadedDomainBuffer; a=nothing, aold=nothing, old_states=nothing, Δt=NaN)
     cellbuffers = buffer.cellbuffers #::TaskLocals
+    sdh = buffer.sdh # SubDofHandler
     update_time!(get_base(cellbuffers), Δt)
     scatter!(cellbuffers)
-    scatter!(assembler)
-    for cellset in buffer.colors
-        Threads.@threads :static for cellnr in cellset
-            id = Threads.threadid()
-            assemble_cell!(get_local(assembler, id), new_states, get_local(cellbuffers, id), buffer.sdh, cellnr, a, aold, old_states)
-        end
-    end
+    scatter!(assemblers)
+    num_tasks = Threads.nthreads()
+    queue_length = typemax(Int)# 2*num_tasks
+    for saved_set_chunks in buffer.saved_set_chunks
+        set_chunks = Channel{Vector{Int}}(queue_length)
+        #set_chunks = ChunkIterator(saved_set_chunks)
+        # Base.Experimental.@sync exits immediately on exception (allow Ctrl+C)
+        Base.Experimental.@sync begin 
+            # Expected that this first task will run until set_chunks is full.
+            # Thereafter, the thread running that task will work on assembling below, 
+            # until `set_chunks` is empty. When one task is put on hold due to no available 
+            # `set_chunk`, the thread working on that task will work on filling up the buffer again.
+            # Once the first item is added, all other tasks can continue and only the one whose thread 
+            # is filling up has to wait for the filling up to be completed.
+            # ChunkIterator can replace the following, but for some reason it is not faster...
+            Threads.@spawn begin
+                for set_chunk in saved_set_chunks
+                    put!(set_chunks, set_chunk)
+                end
+                close(set_chunks)
+            end 
+            # =#
+            
+            for taskid in 1:num_tasks
+                cellbuffer = get_local(cellbuffers, taskid)
+                assembler = get_local(assemblers, taskid)
+                Threads.@spawn begin
+                    for set_chunk in set_chunks
+                        for cellnr in set_chunk
+                            assemble_cell!(assembler, new_states, cellbuffer, sdh, cellnr, a, aold, old_states)
+                        end
+                    end
+                end #spawn
+            end #taskid
+        end #sync
+    end #colors
     gather!(cellbuffers)
-    gather!(assembler)
+    gather!(assemblers)
 end
 
 """

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -55,7 +55,7 @@ function ThreadedDomainBuffer(sdh::SubDofHandler, cellset, colors::Vector, cellb
     cellset_intersect = sort!(collect(intersect(cellset, getcellset(sdh))))
     colors_intersect = map(sort! ∘ collect ∘ Base.Fix1(intersect, cellset_intersect), colors)
     cellbuffers = TaskLocals(cellbuffer)
-    chunk_size = 8
+    chunk_size = 32
     saved_set_chunks = [
         [set[(chunk_size*(i-1)+1):(min(chunk_size*i, length(set)))] for i in 1:ceil(Int, length(set)/chunk_size)]
         for set in colors_intersect]

--- a/test/heatequation.jl
+++ b/test/heatequation.jl
@@ -1,7 +1,7 @@
 @testset "heatequation" begin
     # Modified example from Ferrite.jl
     function get_grid()
-        grid = generate_grid(Quadrilateral, (20, 20))
+        grid = generate_grid(Quadrilateral, (200, 200))
         # Add cellsets for testing different materials on the grid
         addcellset!(grid, "A", x->x[1]<0)
         addcellset!(grid, "B", setdiff(1:getncells(grid), getcellset(grid,"A")))
@@ -184,15 +184,15 @@
         end
     end
     
-    for DH in (DofHandler, MixedDofHandler)
-        for mattype in (:same, :ad, :mixed, :weak)
+    for DH in (DofHandler,)# MixedDofHandler)
+        for mattype in (:same,)# :ad, :mixed, :weak)
             material = materials[mattype]
             
             cv, K, dh = setup_heatequation(DH)
-            for scaling in (FerriteAssembly.NoScaling(), ElementResidualScaling(dh, 1))
+            for scaling in (FerriteAssembly.NoScaling(),)# ElementResidualScaling(dh, 1))
                 r = zeros(ndofs(dh))
                 a = mattype==:same ? nothing : copy(r)  # If AD, dofs required
-                
+                #=
                 @testset "$DH, $mattype, sequential" begin
                     autdiff_cbs = isa(material,ThermalMaterial) ? (false,) : (false, true)
                     for autodiff_cb in autdiff_cbs
@@ -217,6 +217,7 @@
                         end
                     end
                 end
+                =#
                 @testset "$DH, $mattype, threaded" begin
                     autdiff_cbs = isa(material,ThermalMaterial) ? (false,) : (false, true)
                     for autodiff_cb in autdiff_cbs

--- a/test/heatequation.jl
+++ b/test/heatequation.jl
@@ -184,15 +184,15 @@
         end
     end
     
-    for DH in (DofHandler,)# MixedDofHandler)
-        for mattype in (:same,)# :ad, :mixed, :weak)
+    for DH in (DofHandler, MixedDofHandler)
+        for mattype in (:same, :ad, :mixed, :weak)
             material = materials[mattype]
             
             cv, K, dh = setup_heatequation(DH)
-            for scaling in (FerriteAssembly.NoScaling(),)# ElementResidualScaling(dh, 1))
+            for scaling in (FerriteAssembly.NoScaling(), ElementResidualScaling(dh, 1))
                 r = zeros(ndofs(dh))
                 a = mattype==:same ? nothing : copy(r)  # If AD, dofs required
-                #=
+
                 @testset "$DH, $mattype, sequential" begin
                     autdiff_cbs = isa(material,ThermalMaterial) ? (false,) : (false, true)
                     for autodiff_cb in autdiff_cbs
@@ -217,7 +217,7 @@
                         end
                     end
                 end
-                =#
+                
                 @testset "$DH, $mattype, threaded" begin
                     autdiff_cbs = isa(material,ThermalMaterial) ? (false,) : (false, true)
                     for autodiff_cb in autdiff_cbs
@@ -230,7 +230,7 @@
                         # Quick check that test script works and that it is actually colored
                         TDB = FerriteAssembly.ThreadedDomainBuffer
                         @test isa(buffer, Union{Dict{String,<:TDB}, TDB})
-                        
+
                         doassemble!(assembler, new_states, buffer; a=a, old_states=old_states)
                         if isa(scaling, ElementResidualScaling)
                             @test scaling.factors[:u] ≈ sum(abs, r)

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -70,9 +70,9 @@ import .TestIntegrators: MySimpleIntegrand
             # Calculate the values above, but together as a heterogeneous tuple
             tuple_integrator = SimpleIntegrator((u, ∇u, state)->(1.0, u, ∇u), (0.0, 0.0, zero(Vec{3})))
             doassemble!(tuple_integrator, states, buffer; a=a)
-            @test volume_integrator.val == tuple_integrator.val[1]
-            @test dofsum_integrator.val == tuple_integrator.val[2]
-            @test gradsum_integrator.val == tuple_integrator.val[3]
+            @test volume_integrator.val ≈ tuple_integrator.val[1]
+            @test dofsum_integrator.val ≈ tuple_integrator.val[2]
+            @test gradsum_integrator.val ≈ tuple_integrator.val[3]
         end
     
         test_heatflow(;threading=Val(false))
@@ -120,9 +120,9 @@ import .TestIntegrators: MySimpleIntegrand
             # Calculate the values above, but together as a heterogeneous tuple
             tuple_integrator = SimpleIntegrator((u, ∇u, state)->(1.0, u, symmetric(∇u)), (0.0, zero(Vec{2}), zero(SymmetricTensor{2,2})))
             doassemble!(tuple_integrator, states, buffer; a=a)
-            @test area_integrator.val == tuple_integrator.val[1]
-            @test dofsum_integrator.val == tuple_integrator.val[2]
-            @test gradsum_integrator.val == tuple_integrator.val[3]
+            @test area_integrator.val ≈ tuple_integrator.val[1]
+            @test dofsum_integrator.val ≈ tuple_integrator.val[2]
+            @test gradsum_integrator.val ≈ tuple_integrator.val[3]
         end
     
         test_elasticity(;threading=Val(false))
@@ -194,19 +194,15 @@ import .TestIntegrators: MySimpleIntegrand
             # Calculate values from above, but together as a heterogeneous tuple
             tuple_integrator = SimpleIntegrator((u, ∇u, state)->(1.0, u[:p], symmetric(∇u[:u])), (0.0, 0.0, zero(SymmetricTensor{2,2})))
             doassemble!(tuple_integrator, states, buffer; a=a)
-            @test area_integrator.val == tuple_integrator.val[1]
-            @test p_integrator.val == tuple_integrator.val[2]
-            @test ∇u_integrator.val == tuple_integrator.val[3]
+            @test area_integrator.val ≈ tuple_integrator.val[1]
+            @test p_integrator.val ≈ tuple_integrator.val[2]
+            @test ∇u_integrator.val ≈ tuple_integrator.val[3]
 
             # Do the same test, but using Integrator with MySimpleIntegrand
             simple_integrator = SimpleIntegrator((u, ∇u, state)->(1.0, u[:p], symmetric(∇u[:u])), (0.0, 0.0, zero(SymmetricTensor{2,2})))
             integrator = Integrator(MySimpleIntegrand(simple_integrator))
             doassemble!(integrator, states, buffer; a=a)
-            if isa(threading, Val{true})
-                @test all(simple_integrator.val .≈ tuple_integrator.val) # Integrator doesn't thread, so only inexact equality
-            else
-                @test simple_integrator.val == tuple_integrator.val # Should be exact 
-            end
+            @test all(simple_integrator.val .≈ tuple_integrator.val)
         end
 
         test_poroelasticity(;threading=Val(false))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,9 +5,9 @@ import FerriteAssembly as FA
 import FerriteAssembly.ExampleElements as EE
 import MaterialModelsBase as MMB
 
-include("states.jl") 
+#include("states.jl") 
 include("heatequation.jl")
-include("example_elements.jl")
+#=include("example_elements.jl")
 include("integration.jl")
 include("scaling.jl") 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,9 +5,22 @@ import FerriteAssembly as FA
 import FerriteAssembly.ExampleElements as EE
 import MaterialModelsBase as MMB
 
-#include("states.jl") 
+@testset "set_chunks" begin
+    for approx_num_points in (10,100,1000)
+        for num_tasks in (1,2,4,8,16,32)        
+            set = unique!([rand(1:(approx_num_points*10)) for _ in 1:approx_num_points])
+            merged_chunks = Set{Int}()
+            for set_chunk in FerriteAssembly.create_chunks(set; num_tasks=num_tasks)
+                union!(merged_chunks, set_chunk)
+            end
+            @test merged_chunks == Set(set)
+        end
+    end
+end
+
+include("states.jl") 
 include("heatequation.jl")
-#=include("example_elements.jl")
+include("example_elements.jl")
 include("integration.jl")
 include("scaling.jl") 
 


### PR DESCRIPTION
The current `Threads.@threads :static` errors if called from multithreaded code. Had some issues during interactive work/plotting. This should be fixed... A few different implementations are tested in this pr, change `threaded_assemble_domain!` in `assembly.jl` to call 
1. Old implementation, :static
2. Channel implementation, similar to `Ferrite.jl#fe/workstream`
3. Custom ChunkIterator implementation
4. Using `get_chunk(::ChunkIterator) instead of iterating

The main difference is in the number of allocations, time is similar. 
However, I expect that 2-4 are better for unbalanced cases since the workload is (more) balanced. 
