### PR TITLE
New statevariable handling, non-breaking user changes

### DIFF
--- a/docs/src/literate_tutorials/viscoelasticity.jl
+++ b/docs/src/literate_tutorials/viscoelasticity.jl
@@ -85,7 +85,7 @@ end;
 # To setup our problem, we use a simple grid and define all interpolations, quadrature rules, 
 # etc. as normally for `Ferrite` simulations. We also define the `Zener` material and create the 
 # domain buffer. 
-grid = generate_grid(Quadrilateral, 100 .* (2,2))
+grid = generate_grid(Quadrilateral, (2,2))
 ip = geometric_interpolation(Quadrilateral)
 dh = DofHandler(grid)
 add!(dh, :u, ip^2)
@@ -162,9 +162,7 @@ end;
 time_history = collect(range(0,1,10)).^2 
 append!(time_history, 1 .+ collect(range(0,1,10)[2:end]).^2)
 
-@time u1_max, t_force = solve_nonlinear_timehistory(buffer, dh, ch, lh; time_history=time_history[2:end]);
-
-@test sum(abs, u1_max) ≈ 3.9460886561906166 #src
+u1_max, t_force = solve_nonlinear_timehistory(buffer, dh, ch, lh; time_history=time_history[2:end]);
 
 # ## Plot the results 
 fig = CM.Figure()

--- a/docs/src/literate_tutorials/viscoelasticity.jl
+++ b/docs/src/literate_tutorials/viscoelasticity.jl
@@ -85,7 +85,7 @@ end;
 # To setup our problem, we use a simple grid and define all interpolations, quadrature rules, 
 # etc. as normally for `Ferrite` simulations. We also define the `Zener` material and create the 
 # domain buffer. 
-grid = generate_grid(Quadrilateral, (2,2))
+grid = generate_grid(Quadrilateral, 100 .* (2,2))
 ip = geometric_interpolation(Quadrilateral)
 dh = DofHandler(grid)
 add!(dh, :u, ip^2)
@@ -162,7 +162,9 @@ end;
 time_history = collect(range(0,1,10)).^2 
 append!(time_history, 1 .+ collect(range(0,1,10)[2:end]).^2)
 
-u1_max, t_force = solve_nonlinear_timehistory(buffer, dh, ch, lh; time_history=time_history[2:end]);
+@time u1_max, t_force = solve_nonlinear_timehistory(buffer, dh, ch, lh; time_history=time_history[2:end]);
+
+@test sum(abs, u1_max) ≈ 3.9460886561906166 #src
 
 # ## Plot the results 
 fig = CM.Figure()

--- a/src/DomainBuffers.jl
+++ b/src/DomainBuffers.jl
@@ -107,8 +107,7 @@ getset(b::DomainBuffers, domain) = getset(b[domain])
 struct DomainBuffer{I,B,S,SDH<:SubDofHandler} <: AbstractDomainBuffer
     set::Vector{I}
     itembuffer::B
-    states::Dict{Int,S}     # Always indexed by cell. If desired to have 1 state per e.g. facet, need to have e.g. S::Vector{FS}
-    old_states::Dict{Int,S} # For interfaces, it is possible/likely that state_here and state_there can be given. 
+    states::StateVariables{S}
     sdh::SDH
 end
 
@@ -116,16 +115,15 @@ struct ThreadedDomainBuffer{I,B,S,SDH<:SubDofHandler} <: AbstractDomainBuffer
     chunks::Vector{Vector{Vector{I}}}   # I=Int (cell), I=FacetIndex (facet), or
     set::Vector{I}                      # I=NTuple{2,FacetIndex} (interface)
     itembuffer::TaskLocals{B,B}         # cell, facet, or interface buffer 
-    states::Dict{Int,S}                 # To be updated during "work"
-    old_states::Dict{Int,S}             # Only for reference
+    states::StateVariables{S}
     sdh::SDH
 end
-function ThreadedDomainBuffer(set, itembuffer::AbstractItemBuffer, states, old_states, sdh::SubDofHandler, colors_or_chunks=nothing)
+function ThreadedDomainBuffer(set, itembuffer::AbstractItemBuffer, states::StateVariables, sdh::SubDofHandler, colors_or_chunks=nothing)
     grid = _getgrid(sdh)
     set_vector = collect(set)
     chunks = create_chunks(grid, set_vector, colors_or_chunks)
     itembuffers = TaskLocals(itembuffer)
-    return ThreadedDomainBuffer(chunks, set_vector, itembuffers, states, old_states, sdh)
+    return ThreadedDomainBuffer(chunks, set_vector, itembuffers, states, sdh)
 end
 
 get_chunks(db::ThreadedDomainBuffer) = db.chunks
@@ -138,17 +136,15 @@ getset(b::StdDomainBuffer) = b.set
 
 get_dofhandler(b::StdDomainBuffer) = b.sdh.dh
 get_itembuffer(b::StdDomainBuffer) = b.itembuffer
-get_state(b::StdDomainBuffer, cellnum::Int) = fast_getindex(b.states, cellnum)
-get_old_state(b::StdDomainBuffer, cellnum::Int) = fast_getindex(b.old_states, cellnum)
+get_state(b::StdDomainBuffer, cellnum::Int) = fast_getindex(b.states.new, cellnum)
+get_old_state(b::StdDomainBuffer, cellnum::Int) = fast_getindex(b.states.old, cellnum)
 
-get_state(b::StdDomainBuffer) = b.states
-get_old_state(b::StdDomainBuffer) = b.old_states
+get_state(b::StdDomainBuffer) = b.states.new
+get_old_state(b::StdDomainBuffer) = b.states.old
 get_material(b::StdDomainBuffer) = get_material(get_base(get_itembuffer(b)))
 
-# Update old_states = states after convergence 
-function update_states!(b::AbstractDomainBuffer)
-    update_states!(get_old_state(b), get_state(b))
-end
+# Update old_states = new_states after convergence 
+update_states!(b::StdDomainBuffer) = update_states!(b.states)
 
 function set_time_increment!(b::StdDomainBuffer, Δt)
     set_time_increment!(get_base(get_itembuffer(b)), Δt)
@@ -164,3 +160,7 @@ function replace_material(db::ThreadedDomainBuffer, replacement_function)
     itembuffer = TaskLocals(base_ibuf, task_ibuf)
     return _replace_field(db, Val(:itembuffer), itembuffer)
 end
+
+# Experimental: Insert new states, allows reusing the buffer for multiple simulations with same 
+# initial state (grid, dh, etc.), but which experience different loading. Typically for RVE simulations. 
+replace_states!(db::StdDomainBuffer, states::StateVariables) = replace_states!(db.states, states)

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -85,10 +85,10 @@ function setup_itembuffer(adb, domain::DomainSpec{Int}, states)
 end
 
 function _setup_domainbuffer(threaded, domain; a=nothing, autodiffbuffer=Val(false))
-    states = create_states(domain, a)
+    new_states = create_states(domain, a)
     old_states = create_states(domain, a)
-    itembuffer = setup_itembuffer(autodiffbuffer, domain, states)
-    return _setup_domainbuffer(threaded, domain.set, itembuffer, states, old_states, domain.sdh, domain.colors_or_chunks)
+    itembuffer = setup_itembuffer(autodiffbuffer, domain, new_states)
+    return _setup_domainbuffer(threaded, domain.set, itembuffer, StateVariables(old_states, new_states), domain.sdh, domain.colors_or_chunks)
 end
 
 # Type-unstable switch
@@ -96,10 +96,10 @@ function _setup_domainbuffer(threaded::Bool, args...)
     return _setup_domainbuffer(Val(threaded), args...)
 end
 # Sequential
-function _setup_domainbuffer(::Val{false}, set, itembuffer, states, old_states, sdh, args...)
-    return DomainBuffer(set, itembuffer, states, old_states, sdh)
+function _setup_domainbuffer(::Val{false}, set, itembuffer, states, sdh, args...)
+    return DomainBuffer(set, itembuffer, states, sdh)
 end
 # Threaded
-function _setup_domainbuffer(::Val{true}, set, itembuffer, states, old_states, sdh, args...)
-    return ThreadedDomainBuffer(set, itembuffer, states, old_states, sdh, args...)
+function _setup_domainbuffer(::Val{true}, set, itembuffer, states, sdh, args...)
+    return ThreadedDomainBuffer(set, itembuffer, states, sdh, args...)
 end

--- a/test/heatequation.jl
+++ b/test/heatequation.jl
@@ -135,8 +135,8 @@
             ad2 = DomainSpec(dh, material["B"], cv; set=setB)
             buffer = setup_domainbuffers(Dict("A"=>ad1, "B"=>ad2); autodiffbuffer=autodiff_cb, threading=threaded)
             @test isa(buffer, Dict{String,<:BufferType})
-            @test isa(FerriteAssembly.get_old_state(buffer, "A"), Dict{Int})
-            @test isa(FerriteAssembly.get_old_state(buffer, "B"), Dict{Int})
+            @test isa(FerriteAssembly.get_old_state(buffer, "A"), FerriteAssembly.StateVector)
+            @test isa(FerriteAssembly.get_old_state(buffer, "B"), FerriteAssembly.StateVector)
             return buffer
         elseif isa(material, Dict) && length(dh.subdofhandlers) > 1
             sdh1 = dh.subdofhandlers[1]
@@ -151,7 +151,7 @@
             ad4 = DomainSpec(sdh2, material["B"], cv; set=setB) # sdh2B
             buffer = setup_domainbuffers(Dict("sdh1A"=>ad1, "sdh1B"=>ad2, "sdh2A"=>ad3, "sdh2B"=>ad4); autodiffbuffer=autodiff_cb, threading=threaded)
             @test isa(buffer, Dict{String,<:BufferType})
-            @test isa(FerriteAssembly.get_old_state(buffer, "sdh1A"), Dict{Int})
+            @test isa(FerriteAssembly.get_old_state(buffer, "sdh1A"), FerriteAssembly.StateVector)
             return buffer
         elseif length(dh.subdofhandlers) > 1
             sdh1 = dh.subdofhandlers[1]
@@ -161,12 +161,12 @@
             ad2 = DomainSpec(sdh2, material, cv; set=set2)
             buffer = setup_domainbuffers(Dict("sdh1"=>ad1, "sdh2"=>ad2); autodiffbuffer=autodiff_cb, threading=threaded)
             @test isa(buffer, Dict{String,<:BufferType})
-            @test isa(FerriteAssembly.get_old_state(buffer, "sdh1"), Dict{Int})
+            @test isa(FerriteAssembly.get_old_state(buffer, "sdh1"), FerriteAssembly.StateVector)
             return buffer
         else
             buffer = setup_domainbuffer(DomainSpec(dh, material, cv); autodiffbuffer=autodiff_cb, threading=threaded)
             @test isa(buffer, BufferType)
-            @test isa(FerriteAssembly.get_old_state(buffer), Dict{Int})
+            @test isa(FerriteAssembly.get_old_state(buffer), FerriteAssembly.StateVector)
             return buffer
         end
     end

--- a/test/states.jl
+++ b/test/states.jl
@@ -50,88 +50,91 @@ end
     import .TestStateModule: MatA, MatB, MatC, StateA, StateB, StateC
     
     for (CT, Dim) in ((Line, 1), (QuadraticTriangle, 2), (Hexahedron, 3))
-        grid = generate_grid(CT, ntuple(_->3, Dim))
-        ip = geometric_interpolation(CT)
-        dh = DofHandler(grid); add!(dh, :u, ip^Dim); close!(dh);
+        @testset "$CT" begin
+            grid = generate_grid(CT, ntuple(_->3, Dim))
+            ip = geometric_interpolation(CT)
+            dh = DofHandler(grid); add!(dh, :u, ip^Dim); close!(dh);
 
-        K = allocate_matrix(dh)
-        r = zeros(ndofs(dh));
-        kr_assembler = start_assemble(K, r)
-        r_assembler = FerriteAssembly.ReAssembler(r)
-        a = copy(r)
-        RefShape = Ferrite.getrefshape(ip)
-        cv = CellValues(QuadratureRule{RefShape}(2), ip^Dim, ip);
+            K = allocate_matrix(dh)
+            r = zeros(ndofs(dh));
+            kr_assembler = start_assemble(K, r)
+            r_assembler = FerriteAssembly.ReAssembler(r)
+            a = copy(r)
+            RefShape = Ferrite.getrefshape(ip)
+            cv = CellValues(QuadratureRule{RefShape}(2), ip^Dim, ip);
 
-        # MatA: 
-        # - Check correct values before and after update
-        # - Check unaliased old and new after update_states!
-        buffer = setup_domainbuffer(DomainSpec(dh, MatA(), cv))
-        states = FerriteAssembly.get_state(buffer)
-        old_states = FerriteAssembly.get_old_state(buffer)
-        @test isa(old_states, Dict{Int,Vector{StateA}})
-        @test old_states == states
-        @test old_states[1] == [StateA(-1, 0) for _ in 1:getnquadpoints(cv)]
-        work!(r_assembler, buffer)
-        @test old_states[1] == [StateA(-1, 0) for _ in 1:getnquadpoints(cv)] # Unchanged
-        for cellnr in 1:getncells(grid)
-            @test states[cellnr] == [StateA(cellnr, i) for i in 1:getnquadpoints(cv)]  # Updated
-        end
-        update_states!(buffer)
-        @test old_states == states          # Correctly updated values
-        states[1][1] = StateA(0,0)
-        @test old_states[1][1] == StateA(1,1)   # But not aliased
-        allocs = @allocated update_states!(buffer)
-        @test allocs == 0 # Vector{T} where isbitstype(T) should not allocate (MatA fulfills this)
+            # MatA: 
+            # - Check correct values before and after update
+            # - Check unaliased old and new after update_states!
+            buffer = setup_domainbuffer(DomainSpec(dh, MatA(), cv))
+            states = FerriteAssembly.get_state(buffer)
+            old_states = FerriteAssembly.get_old_state(buffer)
+            @test isa(old_states, FerriteAssembly.StateVector{Vector{StateA}})
+            @test old_states == states
+            @test old_states[1] == [StateA(-1, 0) for _ in 1:getnquadpoints(cv)]
+            work!(r_assembler, buffer)
+            @test old_states[1] == [StateA(-1, 0) for _ in 1:getnquadpoints(cv)] # Unchanged
+            for cellnr in 1:getncells(grid)
+                @test states[cellnr] == [StateA(cellnr, i) for i in 1:getnquadpoints(cv)]  # Updated
+            end
+            states_dc = deepcopy(states) # Allowed to update states during update_states!
+            update_states!(buffer)
+            @test old_states == states_dc          # Correctly updated values
+            states[1][1] = StateA(0,0)
+            @test old_states[1][1] == StateA(1,1)   # But not aliased
+            allocs = @allocated update_states!(buffer)
+            @test allocs == 0 # Vector{T} where isbitstype(T) should not allocate (MatA fulfills this)
 
-        # MatB (not bitstype)
-        # - Check correct values before and after update
-        # - Check unaliased old and new after update_states!
-        buffer = setup_domainbuffer(DomainSpec(dh, MatB{Dim}(), cv))
-        states = FerriteAssembly.get_state(buffer)
-        old_states = FerriteAssembly.get_old_state(buffer)
-        @test isa(old_states, Dict{Int,StateB{Dim}})
-        @test old_states == states
-        @test old_states[1] == StateB(-1, [zero(Vec{Dim}) for i in 1:getnquadpoints(cv)])
-        work!(kr_assembler, buffer)
-        @test old_states[1] == StateB(-1, [zero(Vec{Dim}) for i in 1:getnquadpoints(cv)]) # Unchanged
-        for cellnr in 1:getncells(grid)
+            # MatB (not bitstype)
+            # - Check correct values before and after update
+            # - Check unaliased old and new after update_states!
+            buffer = setup_domainbuffer(DomainSpec(dh, MatB{Dim}(), cv))
+            states = FerriteAssembly.get_state(buffer)
+            old_states = FerriteAssembly.get_old_state(buffer)
+            @test isa(old_states, FerriteAssembly.StateVector{StateB{Dim}})
+            @test old_states == states
+            @test old_states[1] == StateB(-1, [zero(Vec{Dim}) for i in 1:getnquadpoints(cv)])
+            work!(kr_assembler, buffer)
+            @test old_states[1] == StateB(-1, [zero(Vec{Dim}) for i in 1:getnquadpoints(cv)]) # Unchanged
+            for cellnr in 1:getncells(grid)
+                coords = getcoordinates(grid, cellnr)
+                x_values = [spatial_coordinate(cv, i, coords) for i in 1:getnquadpoints(cv)]
+                @test states[cellnr] == StateB(cellnr, x_values)                          # Updated
+            end
+            states_dc = deepcopy(states) # Allowed to update states during update_states!
+            update_states!(buffer)
+            @test old_states == states_dc                  # Correctly updated values
+            cellnr = rand(1:getncells(grid))
             coords = getcoordinates(grid, cellnr)
             x_values = [spatial_coordinate(cv, i, coords) for i in 1:getnquadpoints(cv)]
-            @test states[cellnr] == StateB(cellnr, x_values)                          # Updated
-        end
-        update_states!(buffer)
-        @test old_states == states                  # Correctly updated values
-        cellnr = rand(1:getncells(grid))
-        coords = getcoordinates(grid, cellnr)
-        x_values = [spatial_coordinate(cv, i, coords) for i in 1:getnquadpoints(cv)]
-        states[cellnr] = StateB(0, -x_values)
-        @test old_states[cellnr] == StateB(cellnr, x_values)   # But not aliased
-        allocs = @allocated update_states!(buffer)
-        @test allocs > 0 # Vector{T} where !isbitstype(T) is expected to allocate. 
-        # If this fails after improvements, that is just good, but then the docstring should be updated. 
+            states[cellnr] = StateB(0, -x_values)
+            @test old_states[cellnr] == StateB(cellnr, x_values)   # But not aliased
+            allocs = @allocated update_states!(buffer)
+            @test allocs == 0 # Vector{T} where !isbitstype(T) should no longer allocate
 
-        # MatC (accumulation), using threading as well
-        colors = create_coloring(grid)
-        buffer = setup_domainbuffer(DomainSpec(dh, MatC(), cv; colors=colors))
-        states = FerriteAssembly.get_state(buffer)
-        old_states = FerriteAssembly.get_old_state(buffer)
-        @test isa(old_states, Dict{Int,Vector{StateC}})
-        @test old_states == states
-        @test old_states[1][1] == StateC(0)
-        work!(kr_assembler, buffer)
-        @test old_states[1][1] == StateC(0)
-        @test states[1][1] == StateC(1) # Added 1
-        update_states!(buffer)
-        @test old_states[1][1] == StateC(1) # Updated
-        states[1][1] = StateC(0)        # Set states to zero to test aliasing and update in next assembly
-        @test old_states[1][1] == StateC(1) # But not aliased
-        work!(kr_assembler, buffer)
-        @test states[1][1] == StateC(2) # Added 1 from old_states[1][1] (not from states[1][1] which was StateC(0))
-        for cellnr in 1:getncells(grid)
-            @test states[cellnr][2] == StateC(2) # Check that all are updated
+            # MatC (accumulation), using threading as well
+            colors = create_coloring(grid)
+            buffer = setup_domainbuffer(DomainSpec(dh, MatC(), cv; colors=colors))
+            states = FerriteAssembly.get_state(buffer)
+            old_states = FerriteAssembly.get_old_state(buffer)
+            @test isa(old_states, FerriteAssembly.StateVector{Vector{StateC}})
+            @test old_states == states
+            @test old_states[1][1] == StateC(0)
+            work!(kr_assembler, buffer)
+            @test old_states[1][1] == StateC(0)
+            @test states[1][1] == StateC(1) # Added 1
+            update_states!(buffer)
+            @test old_states[1][1] == StateC(1) # Updated
+            states[1][1] = StateC(0)        # Set states to zero to test aliasing and update in next assembly
+            @test old_states[1][1] == StateC(1) # But not aliased
+            work!(kr_assembler, buffer)
+            @test states[1][1] == StateC(2) # Added 1 from old_states[1][1] (not from states[1][1] which was StateC(0))
+            for cellnr in 1:getncells(grid)
+                @test states[cellnr][2] == StateC(2) # Check that all are updated
+            end
+            allocs = @allocated update_states!(buffer)
+            @test allocs == 0 # Vector{T} where isbitstype(T) should not allocate (MatC fulfills this)
         end
-        allocs = @allocated update_states!(buffer)
-        @test allocs == 0 # Vector{T} where isbitstype(T) should not allocate (MatC fulfills this)
     end
 
     ip = Lagrange{RefTriangle,1}()
@@ -140,7 +143,7 @@ end
     # Smoke-test of update_states! for nothing states (and check no allocations)
     cv = CellValues(QuadratureRule{RefTriangle}(2), ip)
     buffer = setup_domainbuffer(DomainSpec(dh, nothing, cv))
-    @test isa(FerriteAssembly.get_state(buffer), Dict{Int,Nothing})
+    @test isa(FerriteAssembly.get_state(buffer), FerriteAssembly.StateVector{Nothing})
     update_states!(buffer) # Compile
     allocs = @allocated update_states!(buffer)
     @test allocs == 0


### PR DESCRIPTION
Wraps the state variables returned to the user in a `StateVector`, but this is also indexed by the cellnumber, hence according to the docs. The key advantage is that this type allows modifying the underlying data by changing a pointer, allowing for easy update of state variables, and this makes it easier to update the state variables if we want to reuse the buffer for multiple simulations, but with different state variables (typical for rve simulations).