### PR TITLE
Add input checking to catch errors leading to wrong results

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,13 +62,7 @@ jobs:
         - uses: julia-actions/setup-julia@v2
           with:
             version: '1'
-        - uses: actions/cache@v4
-          with:
-            path: |
-              ~/.julia/artifacts
-              ~/.julia/packages
-              ~/.julia/registries
-            key: .julia-docs-${{ hashFiles('docs/Project.toml', 'docs/Manifest.toml') }}
+        - uses: julia-actions/cache@v2
         - name: Install dependencies
           run: |
             julia --color=yes --project=docs -e '

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,7 +52,9 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:
-          files: lcov.info    
+          files: lcov.info
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/src/DomainBuffers.jl
+++ b/src/DomainBuffers.jl
@@ -14,6 +14,14 @@ and not the `SubDofHandler` that is local to a specific domain.
 get_dofhandler(db::DomainBuffers) = get_dofhandler(first(values(db)))
 
 """
+    get_grid(dbs::Dict{String,AbstractDomainBuffer})
+    get_grid(db::AbstractDomainBuffer)
+
+Get the underlying `grid::AbstractGrid` from the domain buffers
+"""
+get_grid(db) = Ferrite.get_grid(get_dofhandler(db))
+
+"""
     get_itembuffer(dbs::Dict{String,AbstractDomainBuffer}, domain::String)
     get_itembuffer(db::AbstractDomainBuffer)
 

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -46,15 +46,15 @@ function DomainSpec(dh::DofHandler, args...; kwargs...)
 end
 
 """
-    setup_domainbuffers(domains::Dict{String,DomainSpec}, supress_warnings = false; kwargs...)
+    setup_domainbuffers(domains::Dict{String,DomainSpec}, suppress_warnings = false; kwargs...)
 
 Setup multiple domain buffers, one for each `DomainSpec` in `domains`.
-Set `supress_warnings = true` to supress warnings checking for typical input errors when setting up multiple domains. 
+Set `suppress_warnings = true` to supress warnings checking for typical input errors when setting up multiple domains. 
 See [`setup_domainbuffer`](@ref) for description of the keyword arguments.
 """
-function setup_domainbuffers(domains::Dict{String,<:DomainSpec}, supress_warnings = false; kwargs...)
+function setup_domainbuffers(domains::Dict{String,<:DomainSpec}, suppress_warnings = false; kwargs...)
     dbs = Dict(name => setup_domainbuffer(domain; kwargs...) for (name, domain) in domains)
-    supress_warnings || check_input(dbs)
+    suppress_warnings || check_input(dbs)
     return dbs 
 end
 

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -49,7 +49,7 @@ end
     setup_domainbuffers(domains::Dict{String,DomainSpec}, suppress_warnings = false; kwargs...)
 
 Setup multiple domain buffers, one for each `DomainSpec` in `domains`.
-Set `suppress_warnings = true` to supress warnings checking for typical input errors when setting up multiple domains. 
+Set `suppress_warnings = true` to suppress warnings checking for typical input errors when setting up multiple domains. 
 See [`setup_domainbuffer`](@ref) for description of the keyword arguments.
 """
 function setup_domainbuffers(domains::Dict{String,<:DomainSpec}, suppress_warnings = false; kwargs...)

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -37,6 +37,17 @@
             cb2 = FerriteAssembly.get_itembuffer(db2)
             @test FerriteAssembly.get_user_cache(cb1) !== FerriteAssembly.get_user_cache(cb2)
         end
+        # Warnings for user input mistakes 
+        # Missing cells (hit fewer cells + cells not included)
+        @test_logs (:warn,) (:warn,) setup_domainbuffers(Dict("1" => DomainSpec(dh, CellMatCache(), cv; set = getcellset(grid, "left"))))
+        # Overlapping sets (hit cells not included)
+        @test_logs (:warn,) setup_domainbuffers(Dict(
+            "1" => DomainSpec(dh, CellMatCache(), cv; set = Set(1:50)),
+            "2" => DomainSpec(dh, CellMatCache(), cv; set = Set(1:50))))
+        # Repeated sets (hit more cells)
+        @test_logs (:warn,) setup_domainbuffers(Dict(
+            "1" => DomainSpec(dh, CellMatCache(), cv),
+            "2" => DomainSpec(dh, CellMatCache(), cv)))
     end
     
     @testset "facets" begin


### PR DESCRIPTION
Spent some time figuring out why assembly took so long, but realized that I'd added the full domain 100 times because I forgot to add the cellsets to `DomainSpec`...