### PR TITLE
Coupled buffers for only subdomains

### DIFF
--- a/src/DomainBuffers.jl
+++ b/src/DomainBuffers.jl
@@ -123,7 +123,11 @@ Return new buffer(s) that are coupled with the buffers provided as keyword argum
     match.
 """
 function couple_buffers(dbs::DomainBuffers; kwargs...)
-    return Dict(key => couple_buffers(db; (k => v[key] for (k, v) in kwargs)...) for (key, db) in dbs)
+    return Dict(
+        key => (all(haskey(v, key) for (_, v) in kwargs) ? 
+            couple_buffers(db; (k => v[key] for (k, v) in kwargs)...) :
+            db) for (key, db) in dbs)
+    #return Dict(key => couple_buffers(db; (k => v[key] for (k, v) in kwargs)...) for (key, db) in dbs)
 end
 
 """

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -63,5 +63,13 @@ end
 CoupledSimulations(; kwargs...) = CoupledSimulations(NamedTuple{keys(kwargs)}(values(kwargs)))
 
 function get_domain_simulation(cs::CoupledSimulations, name::String)
-    return CoupledSimulations(map(s -> get_domain_simulation(s, name), cs.sims))
+    # Need to return a named tuple with only the simulations that have a domain called `name`
+    sims = Pair{Symbol, Simulation}[]
+    for (key, sim) in zip(keys(cs.sims), values(cs.sims))
+        if haskey(sim.db, name)
+            push!(sims, key => get_domain_simulation(sim, name))
+        end
+    end
+    return CoupledSimulations(NamedTuple(sims))
+#    return CoupledSimulations(map(s -> get_domain_simulation(s, name), cs.sims))
 end


### PR DESCRIPTION
PoC - works in downstream test (adapted PF-fracture example), needs tests and updated docs before merging. 